### PR TITLE
feat(iroha-connector): add prometheus exporter to the plugin

### DIFF
--- a/packages/cactus-plugin-ledger-connector-iroha2/package.json
+++ b/packages/cactus-plugin-ledger-connector-iroha2/package.json
@@ -58,6 +58,7 @@
     "express": "4.20.0",
     "fast-safe-stringify": "2.1.1",
     "hada": "0.0.8",
+    "prom-client": "15.1.3",
     "rxjs": "7.8.1",
     "sanitize-html": "2.12.1",
     "socket.io": "4.6.2",

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/json/openapi.json
@@ -488,6 +488,10 @@
           }
         }
       },
+      "PrometheusExporterMetricsResponse": {
+        "type": "string",
+        "nullable": false
+      },
       "GenerateTransactionRequestV1": {
         "type": "object",
         "description": "Request for generating transaction or query payload that can be signed on the client side.",
@@ -616,6 +620,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorExceptionResponseV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-iroha2/get-prometheus-exporter-metrics": {
+      "get": {
+        "x-hyperledger-cacti": {
+          "http": {
+            "verbLowerCase": "get",
+            "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-iroha2/get-prometheus-exporter-metrics"
+          }
+        },
+        "operationId": "getPrometheusMetricsV1",
+        "summary": "Get the Prometheus Metrics",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
                 }
               }
             }

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/json/openapi.tpl.json
@@ -488,6 +488,10 @@
           }
         }
       },
+      "PrometheusExporterMetricsResponse": {
+        "type": "string",
+        "nullable": false
+      },
       "GenerateTransactionRequestV1": {
         "type": "object",
         "description": "Request for generating transaction or query payload that can be signed on the client side.",
@@ -616,6 +620,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorExceptionResponseV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-iroha2/get-prometheus-exporter-metrics": {
+      "get": {
+        "x-hyperledger-cacti": {
+          "http": {
+            "verbLowerCase": "get",
+            "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-iroha2/get-prometheus-exporter-metrics"
+          }
+        },
+        "operationId": "getPrometheusMetricsV1",
+        "summary": "Get the Prometheus Metrics",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrometheusExporterMetricsResponse"
                 }
               }
             }

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -661,6 +661,36 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusMetricsV1: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-iroha2/get-prometheus-exporter-metrics`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Executes a query on a Iroha V2 ledger and returns it\'s results.
          * @param {QueryRequestV1} [queryRequestV1] 
          * @param {*} [options] Override http request option.
@@ -750,6 +780,16 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getPrometheusMetricsV1(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPrometheusMetricsV1(options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @summary Executes a query on a Iroha V2 ledger and returns it\'s results.
          * @param {QueryRequestV1} [queryRequestV1] 
          * @param {*} [options] Override http request option.
@@ -792,6 +832,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
+         * @summary Get the Prometheus Metrics
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPrometheusMetricsV1(options?: any): AxiosPromise<string> {
+            return localVarFp.getPrometheusMetricsV1(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @summary Executes a query on a Iroha V2 ledger and returns it\'s results.
          * @param {QueryRequestV1} [queryRequestV1] 
          * @param {*} [options] Override http request option.
@@ -830,6 +879,17 @@ export class DefaultApi extends BaseAPI {
      */
     public generateTransactionV1(generateTransactionRequestV1?: GenerateTransactionRequestV1, options?: AxiosRequestConfig) {
         return DefaultApiFp(this.configuration).generateTransactionV1(generateTransactionRequestV1, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get the Prometheus Metrics
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getPrometheusMetricsV1(options?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).getPrometheusMetricsV1(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/data-fetcher.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/data-fetcher.ts
@@ -1,0 +1,10 @@
+import { Transactions } from "./response.type";
+
+import { totalTxCount, K_CACTUS_IROHA2_TOTAL_TX_COUNT } from "./metrics";
+
+export async function collectMetrics(
+  transactions: Transactions,
+): Promise<void> {
+  transactions.counter++;
+  totalTxCount.labels(K_CACTUS_IROHA2_TOTAL_TX_COUNT).set(transactions.counter);
+}

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/metrics.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/metrics.ts
@@ -1,0 +1,10 @@
+import { Gauge } from "prom-client";
+
+export const K_CACTUS_IROHA2_TOTAL_TX_COUNT = "cactus_iroha2_total_tx_count";
+
+export const totalTxCount = new Gauge({
+  registers: [],
+  name: "cactus_iroha2_total_tx_count",
+  help: "Total transactions executed",
+  labelNames: ["type"],
+});

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/prometheus-exporter.ts
@@ -1,0 +1,39 @@
+import promClient, { Registry } from "prom-client";
+import { Transactions } from "./response.type";
+import { collectMetrics } from "./data-fetcher";
+import { K_CACTUS_IROHA2_TOTAL_TX_COUNT } from "./metrics";
+import { totalTxCount } from "./metrics";
+
+export interface IPrometheusExporterOptions {
+  pollingIntervalInMin?: number;
+}
+
+export class PrometheusExporter {
+  public readonly metricsPollingIntervalInMin: number;
+  public readonly transactions: Transactions = { counter: 0 };
+  public readonly registry: Registry;
+
+  constructor(
+    public readonly prometheusExporterOptions: IPrometheusExporterOptions,
+  ) {
+    this.metricsPollingIntervalInMin =
+      prometheusExporterOptions.pollingIntervalInMin || 1;
+    this.registry = new Registry();
+  }
+
+  public addCurrentTransaction(): void {
+    collectMetrics(this.transactions);
+  }
+
+  public async getPrometheusMetrics(): Promise<string> {
+    const result = await this.registry.getSingleMetricAsString(
+      K_CACTUS_IROHA2_TOTAL_TX_COUNT,
+    );
+    return result;
+  }
+
+  public startMetricsCollection(): void {
+    this.registry.registerMetric(totalTxCount);
+    promClient.collectDefaultMetrics({ register: this.registry });
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/response.type.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/prometheus-exporter/response.type.ts
@@ -1,0 +1,3 @@
+export type Transactions = {
+  counter: number;
+};

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/web-services/get-prometheus-exporter-metrics-endpoint-v1.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/main/typescript/web-services/get-prometheus-exporter-metrics-endpoint-v1.ts
@@ -1,0 +1,110 @@
+import { Express, Request, Response } from "express";
+
+import {
+  registerWebServiceEndpoint,
+  handleRestEndpointException,
+} from "@hyperledger/cactus-core";
+
+import OAS from "../../json/openapi.json";
+
+import {
+  IWebServiceEndpoint,
+  IExpressRequestHandler,
+  IEndpointAuthzOptions,
+} from "@hyperledger/cactus-core-api";
+
+import {
+  LogLevelDesc,
+  Logger,
+  LoggerProvider,
+  Checks,
+  IAsyncProvider,
+} from "@hyperledger/cactus-common";
+
+import { PluginLedgerConnectorIroha2 } from "../plugin-ledger-connector-iroha2";
+
+export interface IGetPrometheusExporterMetricsEndpointV1Options {
+  connector: PluginLedgerConnectorIroha2;
+  logLevel?: LogLevelDesc;
+}
+
+export class GetPrometheusExporterMetricsEndpointV1
+  implements IWebServiceEndpoint
+{
+  private readonly log: Logger;
+
+  constructor(
+    public readonly options: IGetPrometheusExporterMetricsEndpointV1Options,
+  ) {
+    const fnTag = "GetPrometheusExporterMetricsEndpointV1#constructor()";
+
+    Checks.truthy(options, `${fnTag} options`);
+    Checks.truthy(options.connector, `${fnTag} options.connector`);
+
+    const label = "get-prometheus-exporter-metrics-endpoint";
+    const level = options.logLevel || "INFO";
+    this.log = LoggerProvider.getOrCreate({ label, level });
+  }
+
+  getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {
+    // TODO: make this an injectable dependency in the constructor
+    return {
+      get: async () => ({
+        isProtected: true,
+        requiredRoles: [],
+      }),
+    };
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  public get oasPath(): (typeof OAS.paths)["/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-iroha2/get-prometheus-exporter-metrics"] {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-iroha2/get-prometheus-exporter-metrics"
+    ];
+  }
+
+  public getPath(): string {
+    return this.oasPath.get["x-hyperledger-cacti"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    return this.oasPath.get["x-hyperledger-cacti"].http.verbLowerCase;
+  }
+
+  public getOperationId(): string {
+    return this.oasPath.get.operationId;
+  }
+
+  public async registerExpress(
+    expressApp: Express,
+  ): Promise<IWebServiceEndpoint> {
+    await registerWebServiceEndpoint(expressApp, this);
+    return this;
+  }
+
+  async handleRequest(req: Request, res: Response): Promise<void> {
+    const fnTag = "GetPrometheusExporterMetrics#handleRequest()";
+    const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
+    const verbUpper = this.getVerbLowerCase().toUpperCase();
+    this.log.debug(`${verbUpper} ${this.getPath()}`);
+
+    try {
+      const resBody =
+        await this.options.connector.getPrometheusExporterMetrics();
+      res.status(200);
+      res.send(resBody);
+    } catch (ex) {
+      const errorMsg = `${reqTag} ${fnTag} failed to serve request:`;
+
+      await handleRestEndpointException({
+        errorMsg,
+        log: this.log,
+        error: ex,
+        res,
+      });
+    }
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-setup-and-basic-operations.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-setup-and-basic-operations.test.ts
@@ -34,6 +34,7 @@ import {
   generateTestIrohaCredentials,
 } from "../test-helpers/iroha2-env-setup";
 import { addRandomSuffix } from "../test-helpers/utils";
+import { K_CACTUS_IROHA2_TOTAL_TX_COUNT } from "../../../main/typescript/prometheus-exporter/metrics";
 
 setCrypto(crypto);
 
@@ -392,5 +393,25 @@ describe("Setup and basic endpoint tests", () => {
         baseConfig: env.defaultBaseConfig,
       }),
     ).toReject();
+  });
+
+  test("get prometheus exporter metrics", async () => {
+    const res = await env.apiClient.getPrometheusMetricsV1();
+    const promMetricsOutput =
+      "# HELP " +
+      K_CACTUS_IROHA2_TOTAL_TX_COUNT +
+      " Total transactions executed\n" +
+      "# TYPE " +
+      K_CACTUS_IROHA2_TOTAL_TX_COUNT +
+      " gauge\n" +
+      K_CACTUS_IROHA2_TOTAL_TX_COUNT +
+      '{type="' +
+      K_CACTUS_IROHA2_TOTAL_TX_COUNT +
+      '"} 6';
+
+    expect(res).toBeTruthy();
+    expect(res.data).toBeTruthy();
+    expect(res.status).toEqual(200);
+    expect(res.data.includes(promMetricsOutput)).toBeTrue();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10480,6 +10480,7 @@ __metadata:
     hada: "npm:0.0.8"
     jest: "npm:29.6.2"
     jest-extended: "npm:4.0.1"
+    prom-client: "npm:15.1.3"
     rxjs: "npm:7.8.1"
     sanitize-html: "npm:2.12.1"
     socket.io: "npm:4.6.2"


### PR DESCRIPTION
### Commit to be reviewed
---
feat(iroha-connector): add prometheus exporter to the plugin
 
```
Primary Changes
----------------
1. Added Prometheus Exporter to Iroha ledger plugin
2. Added Prometheus Metrics tracker to relevant iroha tests.
```

Fixes #1260


**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.