### PR TITLE
test(ethereum): refactor jest test negative test cases

### DIFF
--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
@@ -24,6 +24,7 @@ import {
   LogLevelDesc,
   IListenOptions,
   Servers,
+  LoggerProvider,
 } from "@hyperledger/cactus-common";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 import { Configuration, Constants } from "@hyperledger/cactus-core-api";
@@ -50,6 +51,12 @@ const containerImageName = "ghcr.io/hyperledger/cacti-geth-all-in-one";
 const containerImageVersion = "2023-07-27-2a8c48ed6";
 
 describe("Ethereum contract deploy and invoke using keychain tests", () => {
+  const logLevel: LogLevelDesc = "info";
+  const log = LoggerProvider.getOrCreate({
+    label: "geth-contract-deploy-and-invoke-using-json-object-v1.test.ts",
+    level: logLevel,
+  });
+
   const keychainEntryKey = uuidV4();
   let testEthAccount: {
       address: HexString;
@@ -227,24 +234,46 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("deployContract without contractJSON should fail", async () => {
-    try {
-      await apiClient.deployContract({
+    await expect(
+      apiClient.deployContract({
         contract: {} as ContractJsonDefinition,
         web3SigningCredential: {
           ethAccount: WHALE_ACCOUNT_ADDRESS,
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-      });
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+      }),
+    ).rejects.toThrow();
+
+    log.info("deployContract failed as expected");
   });
 
   test("deployContract with additional parameters should fail", async () => {
-    try {
-      await apiClient.deployContract({
+    // this try-catch statement was not refactored because calling deployContract with additional parameters is actually not
+    // causing an error.
+
+    // try {
+    //   await apiClient.deployContract({
+    //     contract: {
+    //       contractJSON: HelloWorldContractJson,
+    //     },
+    //     web3SigningCredential: {
+    //       ethAccount: WHALE_ACCOUNT_ADDRESS,
+    //       secret: "",
+    //       type: Web3SigningCredentialType.GethKeychainPassword,
+    //     },
+    //     gas: 1000000,
+    //     fake: 4,
+    //   } as DeployContractV1Request);
+    //   //test is failing because "fail" is not defined. Without the fail statement, the test actually passes.
+    //   fail("Expected deployContract call to fail but it succeeded.");
+    // } catch (error) {
+    //   console.log("deployContract failed as expected");
+    // }
+
+    // have the left the original assertion above as a comment for additional context, this can be removed once this test is debugged. 
+    await expect(
+      apiClient.deployContract({
         contract: {
           contractJSON: HelloWorldContractJson,
         },
@@ -255,11 +284,11 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         },
         gas: 1000000,
         fake: 4,
-      } as DeployContractV1Request);
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+      } as DeployContractV1Request)
+    ).rejects.toThrow();
+
+    log.info("deployContract failed as expected");
+    
   });
 
   //////////////////////////////////
@@ -285,8 +314,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
+    await expect(
+      apiClient.invokeContractV1({
         contract: {
           contractJSON: HelloWorldContractJson,
           contractAddress,
@@ -299,11 +328,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-      });
-      fail("Expected getContractInfoKeychain call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+      }),
+    ).rejects.toBeTruthy();
 
     const getNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -366,8 +392,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
+    await expect(
+      apiClient.invokeContractV1({
         contract: {
           contractJSON: HelloWorldContractJson,
           contractAddress,
@@ -383,11 +409,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: testEthAccount.privateKey,
           type: Web3SigningCredentialType.PrivateKeyHex,
         },
-      });
-      fail("Expected getContractInfoKeychain call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+      }),
+    ).rejects.toBeTruthy();
 
     const invokeGetNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -410,8 +433,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("invokeContractV1 without methodName should fail", async () => {
-    try {
-      await apiClient.invokeContractV1({
+    await expect(
+      apiClient.invokeContractV1({
         contract: {
           contractJSON: HelloWorldContractJson,
           contractAddress,
@@ -423,12 +446,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-      } as InvokeContractV1Request);
-      fail(
-        "Expected deployContractSolBytecodeV1 call to fail but it succeeded.",
-      );
-    } catch (error) {
-      console.log("deployContractSolBytecodeV1 failed as expected");
-    }
+      } as InvokeContractV1Request),
+    ).rejects.toThrow();
+
+    log.info("deployContractSolBytecodeV1 failed as expected");
   });
 });

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -24,6 +24,7 @@ import {
   LogLevelDesc,
   IListenOptions,
   Servers,
+  LoggerProvider,
 } from "@hyperledger/cactus-common";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 import { Configuration, Constants } from "@hyperledger/cactus-core-api";
@@ -54,6 +55,11 @@ const containerImageName = "ghcr.io/hyperledger/cacti-geth-all-in-one";
 const containerImageVersion = "2023-07-27-2a8c48ed6";
 
 describe("Ethereum contract deploy and invoke using keychain tests", () => {
+  const log = LoggerProvider.getOrCreate({
+    label: "geth-contract-deploy-and-invoke-using-keychain-v1.test.ts",
+    level: testLogLevel,
+  });
+
   const keychainEntryKey = uuidV4();
   let testEthAccount: {
       address: HexString;
@@ -230,8 +236,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("deployContract without contractName should fail", async () => {
-    try {
-      await apiClient.deployContract({
+    await expect(
+      apiClient.deployContract({
         contract: {
           keychainId: keychainPlugin.getKeychainId(),
         } as ContractKeychainDefinition,
@@ -240,16 +246,41 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-      });
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+      }),
+    ).rejects.toThrow();
+
+    log.info("deployContract failed as expected");
   });
 
   test("deployContract with additional parameters should fail", async () => {
-    try {
-      await apiClient.deployContract({
+    // did not refactor because the test is not actually failing
+    // it returns a message saying: INFO (PluginLedgerConnectorEthereum): Contract deployed successfully, saving address in keychain entry
+    // it only hits the catch statement because "fail is not defined"
+
+    // try {
+    //   await apiClient.deployContract({
+    //     contract: {
+    //       contractName: HelloWorldContractJson.contractName,
+    //       keychainId: keychainPlugin.getKeychainId(),
+    //     },
+    //     web3SigningCredential: {
+    //       ethAccount: WHALE_ACCOUNT_ADDRESS,
+    //       secret: "",
+    //       type: Web3SigningCredentialType.GethKeychainPassword,
+    //     },
+    //     gas: 1000000,
+    //     fake: 4,
+    //   } as DeployContractV1Request);
+    //   fail("Expected deployContract call to fail but it succeeded.");
+    // } catch (error) {
+    //   log.info("error message:");
+    //   log.info(error.message);
+    //   log.info("deployContract failed as expected");
+    // }
+
+    // have the left the original assertion above as a comment for additional context, this can be removed once this test is debugged. 
+    await expect(
+      apiClient.deployContract({
         contract: {
           contractName: HelloWorldContractJson.contractName,
           keychainId: keychainPlugin.getKeychainId(),
@@ -261,11 +292,11 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         },
         gas: 1000000,
         fake: 4,
-      } as DeployContractV1Request);
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+      } as DeployContractV1Request)
+    ).rejects.toThrow();
+    
+    log.info("deployContract failed as expected");
+
   });
 
   //////////////////////////////////
@@ -291,8 +322,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
+    await expect(
+      apiClient.invokeContractV1({
         contract: {
           contractName: HelloWorldContractJson.contractName,
           keychainId: keychainPlugin.getKeychainId(),
@@ -305,11 +336,10 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-      });
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+      }),
+    ).rejects.toThrow();
+
+    log.info("invokeContractV1 failed as expected");
 
     const getNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -385,16 +415,15 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("runTransactionV1 without transaction config should fail", async () => {
-    try {
-      await apiClient.runTransactionV1({
+    await expect(
+      apiClient.runTransactionV1({
         web3SigningCredential: {
           type: Web3SigningCredentialType.None,
         },
-      } as RunTransactionRequest);
-      fail("Expected runTransactionV1 call to fail but it succeeded.");
-    } catch (error) {
-      console.log("runTransactionV1 failed as expected");
-    }
+      } as RunTransactionRequest),
+    ).rejects.toThrow();
+
+    log.info("runTransactionV1 failed as expected");
   });
 
   test("invoke Web3SigningCredentialType.PrivateKeyHex", async () => {
@@ -420,8 +449,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
+    await expect(
+      apiClient.invokeContractV1({
         contract: {
           contractName: HelloWorldContractJson.contractName,
           keychainId: keychainPlugin.getKeychainId(),
@@ -437,11 +466,10 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: testEthAccount.privateKey,
           type: Web3SigningCredentialType.PrivateKeyHex,
         },
-      });
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+      }),
+    ).rejects.toThrow();
+
+    log.info("invokeContractV1 failed as expected");
 
     const invokeGetNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -490,8 +518,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     expect(setNameOut).toBeTruthy();
     expect(setNameOut.data).toBeTruthy();
 
-    try {
-      await apiClient.invokeContractV1({
+    await expect(
+      apiClient.invokeContractV1({
         contract: {
           contractName: HelloWorldContractJson.contractName,
           keychainId: keychainPlugin.getKeychainId(),
@@ -507,11 +535,10 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-      });
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      expect(error).toBeTruthy();
-    }
+      }),
+    ).rejects.toThrow();
+
+    log.info("invokeContractV1 failed as expected");
 
     const invokeGetNameOut = await apiClient.invokeContractV1({
       contract: {
@@ -530,8 +557,8 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("invokeContractV1 without methodName should fail", async () => {
-    try {
-      await apiClient.invokeContractV1({
+    await expect(
+      apiClient.invokeContractV1({
         contract: {
           contractName: HelloWorldContractJson.contractName,
           keychainId: keychainPlugin.getKeychainId(),
@@ -543,11 +570,10 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-      } as InvokeContractV1Request);
-      fail("Expected invokeContractV1 call to fail but it succeeded.");
-    } catch (error) {
-      console.log("invokeContractV1 failed as expected");
-    }
+      } as InvokeContractV1Request),
+    ).rejects.toThrow();
+
+    log.info("invokeContractV1 failed as expected");
   });
 
   // @todo - move to separate test suite

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
@@ -167,43 +167,49 @@ describe("invokeRawWeb3EthMethod Tests", () => {
   });
 
   test("invokeRawWeb3EthMethod with missing arg throws error (getBlock)", async () => {
-    try {
-      const connectorResponse = connector.invokeRawWeb3EthMethod({
-        methodName: "getBlock",
-      });
+    // did not refactor because the test is not failing.
+    // try {
+    //   const connectorResponse = connector.invokeRawWeb3EthMethod({
+    //     methodName: "getBlock",
+    //   });
 
-      await connectorResponse;
-      fail("Calling getBlock with missing argument should throw an error");
-    } catch (err) {
-      expect(err).toBeTruthy();
-    }
+    //   await connectorResponse;
+    //   //This test is actually passing, but the statement below is not being printed.
+    //   fail("Calling getBlock with missing argument should throw an error");
+    // } catch (err) {
+    //   expect(err).toBeTruthy();
+    // }
+
+    // have the left the original assertion above as a comment for additional context, this can be removed once this test is debugged. 
+    await expect(
+      connector.invokeRawWeb3EthMethod({
+        methodName: "getBlock",
+      })
+    ).rejects.toBeTruthy();
+    
   });
 
   test("invokeRawWeb3EthMethod with invalid arg throws error (getBlock)", async () => {
-    try {
-      const connectorResponse = connector.invokeRawWeb3EthMethod({
+    await expect(
+      connector.invokeRawWeb3EthMethod({
         methodName: "getBlock",
         params: ["foo"],
-      });
+      }),
+    ).rejects.toThrow();
 
-      await connectorResponse;
-      fail("Calling getBlock with argument should throw an error");
-    } catch (err) {
-      expect(err).toBeTruthy();
-    }
+    log.info(
+      "Calling getBlock with an invalid argument threw an error as expected",
+    );
   });
 
   test("invokeRawWeb3EthMethod with non existing method throws error", async () => {
-    try {
-      const connectorResponse = connector.invokeRawWeb3EthMethod({
+    await expect(
+      connector.invokeRawWeb3EthMethod({
         methodName: "foo",
         params: ["foo"],
-      });
+      }),
+    ).rejects.toThrow();
 
-      await connectorResponse;
-      fail("Calling non existing method should throw an error");
-    } catch (err) {
-      expect(err).toBeTruthy();
-    }
+    log.info("Calling non-existing method threw an error as expected");
   });
 });

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-transact-and-gas-fees.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-transact-and-gas-fees.test.ts
@@ -22,6 +22,7 @@ import {
   LogLevelDesc,
   IListenOptions,
   Servers,
+  LoggerProvider,
 } from "@hyperledger/cactus-common";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 import { Configuration, Constants } from "@hyperledger/cactus-core-api";
@@ -41,6 +42,11 @@ const containerImageName = "ghcr.io/hyperledger/cacti-geth-all-in-one";
 const containerImageVersion = "2023-07-27-2a8c48ed6";
 
 describe("Running ethereum transactions with different gas configurations", () => {
+  const log = LoggerProvider.getOrCreate({
+    label: "geth-contract-deploy-and-invoke-using-keychain-v1.test.ts",
+    level: testLogLevel,
+  });
+
   let web3: InstanceType<typeof Web3>,
     addressInfo,
     address: string,
@@ -133,8 +139,8 @@ describe("Running ethereum transactions with different gas configurations", () =
       web3.utils.toWei(2, "gwei"),
     );
 
-    try {
-      await apiClient.runTransactionV1({
+    await expect(
+      apiClient.runTransactionV1({
         web3SigningCredential: {
           ethAccount: WHALE_ACCOUNT_ADDRESS,
           secret: "",
@@ -149,13 +155,10 @@ describe("Running ethereum transactions with different gas configurations", () =
             maxFeePerGas: maxFee,
           },
         },
-      });
-      fail(
-        "Expected runTransactionV1 with mixed config to fail but it succeeded.",
-      );
-    } catch (error) {
-      console.log("runTransactionV1 with mixed config failed as expected");
-    }
+      }),
+    ).rejects.toThrow();
+
+    log.info("runTransactionV1 with mixed config failed as expected");
 
     const balance = await web3.eth.getBalance(testEthAccount.address);
     expect(balance.toString()).toEqual("0");


### PR DESCRIPTION
## **Commit** to be reviewed
test(ethereum): refactor jest test negative test cases
```
Primary Changes
---------------
1. Refactored negative test case exception assertions for cactus-plugin-ledger-connector-ethereum.
Removed try-catch blocks, replaced with declarations through jest-extended's own API.
2. Made comments on specific tests where the tests should fail but are actually passing 
and thus cannot be refactored before being investigated further. 
```

Fixes #3475

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.