### PR TITLE
docs(ledger-browser): add links to documentation 

### DIFF
--- a/packages/cacti-ledger-browser/src/main/typescript/apps/eth/index.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/eth/index.tsx
@@ -13,6 +13,8 @@ import { AppCategory } from "../../common/app-category";
 
 const ethBrowserAppDefinition: AppDefinition = {
   appName: "Ethereum Browser",
+  appDocumentationURL: "https://hyperledger-cacti.github.io/cacti/cactus/ledger-browser/plugin-apps/ethereum-browser/",
+  appSetupGuideURL: "https://hyperledger-cacti.github.io/cacti/cactus/ledger-browser/plugin-apps/ethereum-browser/#setup",
   category: AppCategory.LedgerBrowser,
   defaultInstanceName: "My Eth Browser",
   defaultDescription:

--- a/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/index.tsx
+++ b/packages/cacti-ledger-browser/src/main/typescript/apps/fabric/index.tsx
@@ -15,6 +15,8 @@ import { AppCategory } from "../../common/app-category";
 
 const fabricBrowserAppDefinition: AppDefinition = {
   appName: "Hyperledger Fabric Browser",
+  appDocumentationURL: "https://hyperledger-cacti.github.io/cacti/cactus/ledger-browser/plugin-apps/fabric-browser/",
+  appSetupGuideURL: "https://hyperledger-cacti.github.io/cacti/cactus/ledger-browser/plugin-apps/fabric-browser/#setup",
   category: AppCategory.LedgerBrowser,
   defaultInstanceName: "My Fabric Browser",
   defaultDescription:


### PR DESCRIPTION
``` 
Changes
----------------
1. Added links to documentation and setup guides for eth-browser and fabric-browser.
```
Fixes #3550 

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.