### PR TITLE
feat(fabric): serialization of ccp and sshconfig

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/deploy-contract-go-source/deploy-contract-go-source-impl-fabric-v2-5-6.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/deploy-contract-go-source/deploy-contract-go-source-impl-fabric-v2-5-6.ts
@@ -3,6 +3,7 @@ import temp from "temp";
 import fs from "fs/promises";
 
 import {
+  Config as SshConfig,
   NodeSSH,
   SSHExecCommandOptions,
   SSHExecCommandResponse,
@@ -35,6 +36,7 @@ export interface IDeployContractGoSourceImplFabricV256Context {
   readonly log: Logger;
   readonly className: string;
   readonly dockerBinary: string;
+  readonly sshConfig: SshConfig;
   readonly opts: IPluginLedgerConnectorFabricOptions;
 }
 
@@ -53,7 +55,7 @@ export async function deployContractGoSourceImplFabricV256(
     ctx.opts.cliContainerGoPath || K_DEFAULT_CLI_CONTAINER_GO_PATH;
 
   const ssh = new NodeSSH();
-  await ssh.connect(ctx.opts.sshConfig);
+  await ssh.connect(ctx.sshConfig);
   log.debug(`SSH connection OK`);
 
   try {

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -251,6 +251,32 @@ describe(testCase, () => {
     }
 
     {
+      const connectionProfileString = JSON.stringify(connectionProfile);
+      const connectionProfileB64Buffer = Buffer.from(connectionProfileString);
+      const sshConfigString = JSON.stringify(sshConfig);
+      const connectionProfileB64 =
+        connectionProfileB64Buffer.toString("base64");
+      const sshConfigB64Buffer = Buffer.from(sshConfigString);
+      const sshConfigB64 = sshConfigB64Buffer.toString("base64");
+      const pluginOptionsSerialized: IPluginLedgerConnectorFabricOptions = {
+        instanceId: uuidv4(),
+        pluginRegistry,
+        sshConfigB64,
+        cliContainerEnv: {},
+        peerBinary: "/fabric-samples/bin/peer",
+        logLevel,
+        connectionProfileB64,
+        discoveryOptions,
+        eventHandlerOptions: {
+          strategy: DefaultEventHandlerStrategy.NetworkScopeAllfortx,
+          commitTimeout: 300,
+        },
+      };
+      const pluginWithSerializedInputs = new PluginLedgerConnectorFabric(
+        pluginOptionsSerialized,
+      );
+      await pluginWithSerializedInputs.getOrCreateWebServices();
+      await pluginWithSerializedInputs.registerWebServices(expressApp);
       const req: RunTransactionRequest = {
         signingCredential,
         gatewayOptions: {


### PR DESCRIPTION
## Commit to be reviewed

feat(fabric): serialization of ccp and sshconfig 
  
    Primary Changes
    ---------------
    1. sshConfig and connectionProfile can now be passed as base64 encoded strings

    Changes required to incorporate 1)
    ---------------------------------
    2. Added sshConfigBase64Encoded and connectionProfileBase64encoded properties to IPluginLedgerConnectorFabricOptions
    3. Added necessary FabricConnector class variables
    4. Added a new testcase to demonstrate the same
    5. Updated an implementation which fetches sshConfig from class variable

Fixes #3577

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.