### PR TITLE
fix(besu): deployContractSolBytecodeNoKeychainV1 requires keychainId

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/api/openapi.yaml
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/api/openapi.yaml
@@ -1024,7 +1024,6 @@ components:
         web3SigningCredential:
           type: null
         contractName: contractName
-        contractJSONString: contractJSONString
         gasPrice: gasPrice
       properties:
         contractName:
@@ -1038,11 +1037,6 @@ components:
           items: {}
           nullable: false
           type: array
-        contractJSONString:
-          description: "For use when not using keychain, pass the contract in as this\
-            \ string variable"
-          nullable: false
-          type: string
         constructorArgs:
           default: []
           items: {}
@@ -1076,9 +1070,7 @@ components:
       - bytecode
       - constructorArgs
       - contractAbi
-      - contractJson
       - contractName
-      - keychainId
       - web3SigningCredential
       type: object
     DeployContractSolidityBytecodeV1Response:

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/model_deploy_contract_solidity_bytecode_no_keychain_v1_request.go
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/model_deploy_contract_solidity_bytecode_no_keychain_v1_request.go
@@ -23,8 +23,6 @@ type DeployContractSolidityBytecodeNoKeychainV1Request struct {
 	ContractName string `json:"contractName"`
 	// The application binary interface of the solidity contract
 	ContractAbi []interface{} `json:"contractAbi"`
-	// For use when not using keychain, pass the contract in as this string variable
-	ContractJSONString *string `json:"contractJSONString,omitempty"`
 	ConstructorArgs []interface{} `json:"constructorArgs"`
 	Web3SigningCredential Web3SigningCredential `json:"web3SigningCredential"`
 	// See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode
@@ -108,38 +106,6 @@ func (o *DeployContractSolidityBytecodeNoKeychainV1Request) GetContractAbiOk() (
 // SetContractAbi sets field value
 func (o *DeployContractSolidityBytecodeNoKeychainV1Request) SetContractAbi(v []interface{}) {
 	o.ContractAbi = v
-}
-
-// GetContractJSONString returns the ContractJSONString field value if set, zero value otherwise.
-func (o *DeployContractSolidityBytecodeNoKeychainV1Request) GetContractJSONString() string {
-	if o == nil || IsNil(o.ContractJSONString) {
-		var ret string
-		return ret
-	}
-	return *o.ContractJSONString
-}
-
-// GetContractJSONStringOk returns a tuple with the ContractJSONString field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *DeployContractSolidityBytecodeNoKeychainV1Request) GetContractJSONStringOk() (*string, bool) {
-	if o == nil || IsNil(o.ContractJSONString) {
-		return nil, false
-	}
-	return o.ContractJSONString, true
-}
-
-// HasContractJSONString returns a boolean if a field has been set.
-func (o *DeployContractSolidityBytecodeNoKeychainV1Request) HasContractJSONString() bool {
-	if o != nil && !IsNil(o.ContractJSONString) {
-		return true
-	}
-
-	return false
-}
-
-// SetContractJSONString gets a reference to the given string and assigns it to the ContractJSONString field.
-func (o *DeployContractSolidityBytecodeNoKeychainV1Request) SetContractJSONString(v string) {
-	o.ContractJSONString = &v
 }
 
 // GetConstructorArgs returns the ConstructorArgs field value
@@ -354,9 +320,6 @@ func (o DeployContractSolidityBytecodeNoKeychainV1Request) ToMap() (map[string]i
 	toSerialize := map[string]interface{}{}
 	toSerialize["contractName"] = o.ContractName
 	toSerialize["contractAbi"] = o.ContractAbi
-	if !IsNil(o.ContractJSONString) {
-		toSerialize["contractJSONString"] = o.ContractJSONString
-	}
 	toSerialize["constructorArgs"] = o.ConstructorArgs
 	toSerialize["web3SigningCredential"] = o.Web3SigningCredential
 	toSerialize["bytecode"] = o.Bytecode

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
@@ -766,10 +766,8 @@
         "required": [
           "contractName",
           "contractAbi",
-          "contractJson",
           "bytecode",
           "web3SigningCredential",
-          "keychainId",
           "constructorArgs"
         ],
         "additionalProperties": false,
@@ -786,11 +784,6 @@
             "type": "array",
             "items": {},
             "nullable": false
-          },
-          "contractJSONString": {
-            "description": "For use when not using keychain, pass the contract in as this string variable",
-            "nullable": false,
-            "type": "string"
           },
           "constructorArgs": {
             "type": "array",

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.tpl.json
@@ -766,10 +766,8 @@
         "required": [
           "contractName",
           "contractAbi",
-          "contractJson",
           "bytecode",
           "web3SigningCredential",
-          "keychainId",
           "constructorArgs"
         ],
         "additionalProperties": false,
@@ -786,11 +784,6 @@
             "type": "array",
             "items": {},
             "nullable": false
-          },
-          "contractJSONString": {
-            "description": "For use when not using keychain, pass the contract in as this string variable",
-            "nullable": false,
-            "type": "string"
           },
           "constructorArgs": {
             "type": "array",

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/proto/generated/openapi/models/deploy_contract_solidity_bytecode_no_keychain_v1_request_pb.proto
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/proto/generated/openapi/models/deploy_contract_solidity_bytecode_no_keychain_v1_request_pb.proto
@@ -25,9 +25,6 @@ message DeployContractSolidityBytecodeNoKeychainV1RequestPB {
   // The application binary interface of the solidity contract
   repeated google.protobuf.Any contractAbi = 512852493;
 
-  // For use when not using keychain, pass the contract in as this string variable
-  string contractJSONString = 405816750;
-
   repeated google.protobuf.Any constructorArgs = 336490508;
 
   Web3SigningCredentialPB web3SigningCredential = 451211679;

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -151,12 +151,6 @@ export interface DeployContractSolidityBytecodeNoKeychainV1Request {
      */
     'contractAbi': Array<any>;
     /**
-     * For use when not using keychain, pass the contract in as this string variable
-     * @type {string}
-     * @memberof DeployContractSolidityBytecodeNoKeychainV1Request
-     */
-    'contractJSONString'?: string;
-    /**
      * 
      * @type {Array<any>}
      * @memberof DeployContractSolidityBytecodeNoKeychainV1Request

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/proto/protoc-gen-ts/models/deploy_contract_solidity_bytecode_no_keychain_v1_request_pb.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/proto/protoc-gen-ts/models/deploy_contract_solidity_bytecode_no_keychain_v1_request_pb.ts
@@ -13,7 +13,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
         constructor(data?: any[] | {
             contractName?: string;
             contractAbi?: dependency_1.google.protobuf.Any[];
-            contractJSONString?: string;
             constructorArgs?: dependency_1.google.protobuf.Any[];
             web3SigningCredential?: dependency_3.org.hyperledger.cacti.plugin.ledger.connector.besu.Web3SigningCredentialPB;
             bytecode?: string;
@@ -30,9 +29,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
                 }
                 if ("contractAbi" in data && data.contractAbi != undefined) {
                     this.contractAbi = data.contractAbi;
-                }
-                if ("contractJSONString" in data && data.contractJSONString != undefined) {
-                    this.contractJSONString = data.contractJSONString;
                 }
                 if ("constructorArgs" in data && data.constructorArgs != undefined) {
                     this.constructorArgs = data.constructorArgs;
@@ -68,12 +64,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
         }
         set contractAbi(value: dependency_1.google.protobuf.Any[]) {
             pb_1.Message.setRepeatedWrapperField(this, 512852493, value);
-        }
-        get contractJSONString() {
-            return pb_1.Message.getFieldWithDefault(this, 405816750, "") as string;
-        }
-        set contractJSONString(value: string) {
-            pb_1.Message.setField(this, 405816750, value);
         }
         get constructorArgs() {
             return pb_1.Message.getRepeatedWrapperField(this, dependency_1.google.protobuf.Any, 336490508) as dependency_1.google.protobuf.Any[];
@@ -126,7 +116,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
         static fromObject(data: {
             contractName?: string;
             contractAbi?: ReturnType<typeof dependency_1.google.protobuf.Any.prototype.toObject>[];
-            contractJSONString?: string;
             constructorArgs?: ReturnType<typeof dependency_1.google.protobuf.Any.prototype.toObject>[];
             web3SigningCredential?: ReturnType<typeof dependency_3.org.hyperledger.cacti.plugin.ledger.connector.besu.Web3SigningCredentialPB.prototype.toObject>;
             bytecode?: string;
@@ -141,9 +130,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
             }
             if (data.contractAbi != null) {
                 message.contractAbi = data.contractAbi.map(item => dependency_1.google.protobuf.Any.fromObject(item));
-            }
-            if (data.contractJSONString != null) {
-                message.contractJSONString = data.contractJSONString;
             }
             if (data.constructorArgs != null) {
                 message.constructorArgs = data.constructorArgs.map(item => dependency_1.google.protobuf.Any.fromObject(item));
@@ -172,7 +158,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
             const data: {
                 contractName?: string;
                 contractAbi?: ReturnType<typeof dependency_1.google.protobuf.Any.prototype.toObject>[];
-                contractJSONString?: string;
                 constructorArgs?: ReturnType<typeof dependency_1.google.protobuf.Any.prototype.toObject>[];
                 web3SigningCredential?: ReturnType<typeof dependency_3.org.hyperledger.cacti.plugin.ledger.connector.besu.Web3SigningCredentialPB.prototype.toObject>;
                 bytecode?: string;
@@ -186,9 +171,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
             }
             if (this.contractAbi != null) {
                 data.contractAbi = this.contractAbi.map((item: dependency_1.google.protobuf.Any) => item.toObject());
-            }
-            if (this.contractJSONString != null) {
-                data.contractJSONString = this.contractJSONString;
             }
             if (this.constructorArgs != null) {
                 data.constructorArgs = this.constructorArgs.map((item: dependency_1.google.protobuf.Any) => item.toObject());
@@ -221,8 +203,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
                 writer.writeString(328784197, this.contractName);
             if (this.contractAbi.length)
                 writer.writeRepeatedMessage(512852493, this.contractAbi, (item: dependency_1.google.protobuf.Any) => item.serialize(writer));
-            if (this.contractJSONString.length)
-                writer.writeString(405816750, this.contractJSONString);
             if (this.constructorArgs.length)
                 writer.writeRepeatedMessage(336490508, this.constructorArgs, (item: dependency_1.google.protobuf.Any) => item.serialize(writer));
             if (this.has_web3SigningCredential)
@@ -251,9 +231,6 @@ export namespace org.hyperledger.cacti.plugin.ledger.connector.besu {
                         break;
                     case 512852493:
                         reader.readMessage(message.contractAbi, () => pb_1.Message.addToRepeatedWrapperField(message, 512852493, dependency_1.google.protobuf.Any.deserialize(reader), dependency_1.google.protobuf.Any));
-                        break;
-                    case 405816750:
-                        message.contractJSONString = reader.readString();
                         break;
                     case 336490508:
                         reader.readMessage(message.constructorArgs, () => pb_1.Message.addToRepeatedWrapperField(message, 336490508, dependency_1.google.protobuf.Any.deserialize(reader), dependency_1.google.protobuf.Any));

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/impl/deploy-contract-v1/deploy-contract-v1-keychain.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/impl/deploy-contract-v1/deploy-contract-v1-keychain.ts
@@ -35,11 +35,11 @@ export async function deployContractV1Keychain(
   },
   req: DeployContractSolidityBytecodeV1Request,
 ): Promise<IDeployContractV1KeychainResponse> {
-  const fnTag = `deployContract()`;
+  const fnTag = `deployContractV1Keychain()`;
   Checks.truthy(req, `${fnTag} req`);
 
   const log = LoggerProvider.getOrCreate({
-    label: "getBlockV1Impl()",
+    label: fnTag,
     level: ctx.logLevel,
   });
 

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/impl/transact-v1/transact-v1-signed.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/impl/transact-v1/transact-v1-signed.ts
@@ -29,7 +29,7 @@ export async function transactV1Signed(
     `${fnTag}:req.transactionConfig.rawTransaction`,
   );
   const log = LoggerProvider.getOrCreate({
-    label: "getBlockGrpc()",
+    label: "transactV1Signed()",
     level: ctx.logLevel,
   });
   const rawTx = req.transactionConfig.rawTransaction as string;
@@ -53,7 +53,7 @@ export async function getTxReceipt(
   const fnTag = `getTxReceipt()`;
 
   const log = LoggerProvider.getOrCreate({
-    label: "getBlockGrpc()",
+    label: "getTxReceipt",
     level: ctx.logLevel,
   });
   log.debug("Received preliminary receipt from Besu node.");
@@ -103,7 +103,7 @@ export async function pollForTxReceipt(
 ): Promise<TransactionReceipt> {
   const fnTag = `pollForTxReceipt()`;
   const log = LoggerProvider.getOrCreate({
-    label: "getBlockGrpc()",
+    label: "pollForTxReceipt()",
     level: ctx.logLevel,
   });
   let txReceipt;

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/deploy-contract-solidity-bytecode-no-keychain-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/web-services/deploy-contract-solidity-bytecode-no-keychain-endpoint.ts
@@ -20,7 +20,7 @@ import {
 } from "@hyperledger/cactus-core";
 
 import { PluginLedgerConnectorBesu } from "../plugin-ledger-connector-besu";
-import { DeployContractSolidityBytecodeV1Request } from "../generated/openapi/typescript-axios";
+import type { DeployContractSolidityBytecodeNoKeychainV1Request } from "../generated/openapi/typescript-axios";
 import OAS from "../../json/openapi.json";
 
 export interface IDeployContractSolidityBytecodeNoKeychainOptions {
@@ -96,7 +96,7 @@ export class DeployContractSolidityBytecodeNoKeychainEndpoint
     const fnTag = `${this.className}#handleRequest()`;
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
-    const reqBody: DeployContractSolidityBytecodeV1Request = req.body;
+    const reqBody: DeployContractSolidityBytecodeNoKeychainV1Request = req.body;
     try {
       const resBody =
         await this.options.connector.deployContractNoKeychain(reqBody);

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/v21-deploy-contract-from-json-no-keychain.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/v21-deploy-contract-from-json-no-keychain.test.ts
@@ -186,11 +186,9 @@ describe("PluginLedgerConnectorBesu", () => {
   });
 
   test("deploys contract via .json file", async () => {
-    const contractJSONString = JSON.stringify(HelloWorldContractJson);
     const deployOut = await connector.deployContractNoKeychain({
       contractName: HelloWorldContractJson.contractName,
       contractAbi: HelloWorldContractJson.abi,
-      contractJSONString: contractJSONString,
       constructorArgs: [],
       web3SigningCredential: {
         ethAccount: firstHighNetWorthAccount,


### PR DESCRIPTION
In the DeployContractSolidityBytecodeNoKeychainV1Request of
`packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.tpl.json`
there are parameters that are required despite the entire point of this
operation is to not need them (e.g. keychainId and contract JSON object).

Fixes #3586

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.