### PR TITLE
test(cmd-api-server): jestify grpc-proto-gen-ts-client-healthcheck test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -437,7 +437,7 @@ jobs:
       JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-cmd-api-server
       JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
-        --files={./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/certificates-work-for-mutual-tls.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/generates-working-certificates.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-js-proto-loader-client-healthcheck.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-healthcheck.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-m-tls-enabled.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts}
+        --files={./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/certificates-work-for-mutual-tls.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/generates-working-certificates.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-js-proto-loader-client-healthcheck.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-m-tls-enabled.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
     runs-on: ubuntu-22.04
     steps:

--- a/.taprc
+++ b/.taprc
@@ -48,7 +48,6 @@ files:
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/generates-working-certificates.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/certificates-work-for-mutual-tls.test.ts
-  - ./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-healthcheck.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-js-proto-loader-client-healthcheck.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-m-tls-enabled.test.ts
   - ./extensions/cactus-plugin-object-store-ipfs/src/test/typescript/integration/plugin-object-store-ipfs.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -61,7 +61,6 @@ module.exports = {
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/generates-working-certificates.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/certificates-work-for-mutual-tls.test.ts`,
-    `./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-healthcheck.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-js-proto-loader-client-healthcheck.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-m-tls-enabled.test.ts`,
     `./extensions/cactus-plugin-object-store-ipfs/src/test/typescript/integration/plugin-object-store-ipfs.test.ts`,

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/config/config-service-example-config-validity.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/config/config-service-example-config-validity.test.ts
@@ -11,9 +11,7 @@ import {
 import { ApiServer } from "../../../../main/typescript/public-api";
 import { ConfigService } from "../../../../main/typescript/public-api";
 
-const testcase = "";
-
-describe(testcase, () => {
+describe("ConfigService", () => {
   const configService = new ConfigService();
   let apiServer: ApiServer,
     exampleConfig: ICactusApiServerOptions,
@@ -24,7 +22,7 @@ describe(testcase, () => {
     exampleConfig = await configService.newExampleConfig();
     const pluginsPath = path.join(
       __dirname,
-      "../../../../../../", // walk back up to the project root
+      "../../../../../../../", // walk back up to the project root
       ".tmp/test/test-cmd-api-server/config-service-example-config-validity_test/", // the dir path from the root
       uuidv4(), // then a random directory to ensure proper isolation
     );

--- a/packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-healthcheck.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-healthcheck.test.ts
@@ -1,88 +1,97 @@
-import test, { Test } from "tape-promise/tape";
-
+import "jest-extended";
 import * as grpc from "@grpc/grpc-js";
+import { RuntimeError } from "run-time-error-cjs";
 
 import { LogLevelDesc } from "@hyperledger/cactus-common";
 
-import { ApiServer, ConfigService } from "../../../main/typescript/public-api";
+import {
+  ApiServer,
+  ConfigService,
+  ICactusApiServerOptions,
+} from "../../../main/typescript/public-api";
 import { AuthorizationProtocol } from "../../../main/typescript/public-api";
 import { default_service } from "../../../main/typescript/public-api";
 import { health_check_response_pb } from "../../../main/typescript/public-api";
 import { empty } from "../../../main/typescript/public-api";
-import { RuntimeError } from "run-time-error-cjs";
 
-const testCase = "API server: runs gRPC TS-proto web services";
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 
-test(testCase, async (t: Test) => {
-  const configService = new ConfigService();
-  const apiSrvOpts = await configService.newExampleConfig();
-  apiSrvOpts.authorizationProtocol = AuthorizationProtocol.NONE;
-  apiSrvOpts.configFile = "";
-  apiSrvOpts.logLevel = logLevel;
-  apiSrvOpts.apiCorsDomainCsv = "*";
-  apiSrvOpts.apiPort = 0;
-  apiSrvOpts.grpcPort = 0;
-  apiSrvOpts.crpcPort = 0;
-  apiSrvOpts.cockpitPort = 0;
-  apiSrvOpts.grpcMtlsEnabled = false;
-  apiSrvOpts.apiTlsEnabled = false;
-  apiSrvOpts.plugins = [];
-  const config = await configService.newExampleConfigConvict(apiSrvOpts);
+describe("ApiServer", () => {
+  let apiServer: ApiServer;
+  let config: ICactusApiServerOptions;
+  let apiClient: default_service.org.hyperledger.cactus.cmd_api_server.DefaultServiceClient;
 
-  const apiServer = new ApiServer({
-    config: config.getProperties(),
+  afterAll(async () => {
+    await apiServer.shutdown();
   });
-  test.onFinish(async () => await apiServer.shutdown());
 
-  const startResponse = apiServer.start();
-  await t.doesNotReject(
-    startResponse,
-    "failed to start API server with dynamic plugin imports configured for it...",
-  );
-  t.ok(startResponse, "startResponse truthy OK");
+  beforeAll(async () => {
+    const configService = new ConfigService();
+    const apiSrvOpts = await configService.newExampleConfig();
+    apiSrvOpts.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiSrvOpts.configFile = "";
+    apiSrvOpts.logLevel = logLevel;
+    apiSrvOpts.apiCorsDomainCsv = "*";
+    apiSrvOpts.apiPort = 0;
+    apiSrvOpts.grpcPort = 0;
+    apiSrvOpts.crpcPort = 0;
+    apiSrvOpts.cockpitPort = 0;
+    apiSrvOpts.grpcMtlsEnabled = false;
+    apiSrvOpts.apiTlsEnabled = false;
+    apiSrvOpts.plugins = [];
+    const convictCfg = await configService.newExampleConfigConvict(apiSrvOpts);
+    config = convictCfg.getProperties();
 
-  const addressInfoGrpc = (await startResponse).addressInfoGrpc;
-  const { address, port } = addressInfoGrpc;
-  const grpcHostAndPort = `${address}:${port}`;
+    apiServer = new ApiServer({
+      config,
+    });
 
-  const apiClient =
-    new default_service.org.hyperledger.cactus.cmd_api_server.DefaultServiceClient(
-      grpcHostAndPort,
-      grpc.credentials.createInsecure(),
-    );
-  t.ok(apiClient, "apiClient truthy OK");
+    const apiServerStart = apiServer.start();
+    await expect(apiServerStart).toResolve();
+    const addressInfoGrpc = (await apiServerStart).addressInfoGrpc;
+    const { address, port } = addressInfoGrpc;
+    const grpcHostAndPort = `${address}:${port}`;
 
-  const responsePromise =
-    new Promise<health_check_response_pb.org.hyperledger.cactus.cmd_api_server.HealthCheckResponsePB>(
-      (resolve, reject) => {
-        apiClient.GetHealthCheckV1(
-          new empty.google.protobuf.Empty(),
-          (
-            error: grpc.ServiceError | null,
-            response?: health_check_response_pb.org.hyperledger.cactus.cmd_api_server.HealthCheckResponsePB,
-          ) => {
-            if (error) {
-              reject(error);
-            } else if (response) {
-              resolve(response);
-            } else {
-              throw new RuntimeError("No error, nor response received.");
-            }
-          },
-        );
-      },
-    );
+    apiClient =
+      new default_service.org.hyperledger.cactus.cmd_api_server.DefaultServiceClient(
+        grpcHostAndPort,
+        grpc.credentials.createInsecure(),
+      );
+    expect(apiClient).toBeTruthy();
+  });
 
-  await t.doesNotReject(responsePromise, "No error in healthcheck OK");
-  const res = await responsePromise;
+  test("runs gRPC TS-proto web services", async () => {
+    type HealthCheckResponsePB =
+      health_check_response_pb.org.hyperledger.cactus.cmd_api_server.HealthCheckResponsePB;
 
-  const resHc = res?.toObject();
+    const grpcReq = new Promise<HealthCheckResponsePB>((resolve, reject) => {
+      apiClient.GetHealthCheckV1(
+        new empty.google.protobuf.Empty(),
+        (error: grpc.ServiceError | null, response?: HealthCheckResponsePB) => {
+          if (error) {
+            reject(error);
+          } else if (response) {
+            resolve(response);
+          } else {
+            reject(new RuntimeError("No error, nor response received."));
+          }
+        },
+      );
+    });
 
-  t.ok(resHc, `healthcheck response truthy OK`);
-  t.ok(resHc?.createdAt, `resHc.createdAt truthy OK`);
-  t.ok(resHc?.memoryUsage, `resHc.memoryUsage truthy OK`);
-  t.ok(resHc?.memoryUsage?.rss, `resHc.memoryUsage.rss truthy OK`);
-  t.ok(resHc?.success, `resHc.success truthy OK`);
-  t.end();
+    await expect(grpcReq).resolves.toMatchObject({
+      toObject: expect.toBeFunction(),
+    });
+
+    const resPb = await grpcReq;
+    const res = resPb.toObject();
+
+    expect(res).toMatchObject({
+      createdAt: expect.toBeDateString(),
+      memoryUsage: expect.objectContaining({
+        rss: expect.toBeNumber(),
+      }),
+      success: true,
+    });
+  });
 });


### PR DESCRIPTION
1. Also fixing a minor bug in config/config-service-example-config-validity.test.ts
where the path of the temporary files generated by the test were being saved
in the wrong directory instead of $PROJECT_ROOT/.tmp/...

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.