### PR TITLE
build: migrate to Typescript target of ES2022 and use Error.cause

### DIFF
--- a/examples/cactus-example-supply-chain-frontend/tsconfig.json
+++ b/examples/cactus-example-supply-chain-frontend/tsconfig.json
@@ -14,7 +14,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "lib": [
-      "es2018",
+      "ES2022",
       "dom"
     ],
     "resolveJsonModule": true,

--- a/examples/test-run-transaction/tsconfig.json
+++ b/examples/test-run-transaction/tsconfig.json
@@ -2,12 +2,10 @@
   "compilerOptions": {
     /* Basic Options */
     "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2017", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "ES2022", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "CommonJS", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": [
-      "es2015",
-      "es2016",
-      "es2017",
+      "ES2022",
       "dom"
     ], /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/packages/cactus-common/src/main/typescript/exception/create-runtime-error-with-cause.ts
+++ b/packages/cactus-common/src/main/typescript/exception/create-runtime-error-with-cause.ts
@@ -2,6 +2,25 @@ import { RuntimeError } from "run-time-error-cjs";
 import { coerceUnknownToError } from "./coerce-unknown-to-error";
 
 /**
+ * ## DEPRECATED
+ *
+ * Instead of relying on this function, in the future, use the new `cause`
+ * property of the built-in `Error` type in combination
+ * with the `asError(unknown)` utility function:
+ * ```typescript
+ * import { asError } from "@hyperledger/cactus-common";
+ *
+ * try {
+ *   await performSomeImportantOperation();
+ * } catch (ex: unknown) {
+ *  const cause = asError(ex);
+ *   throw new Error("Something went wrong while doing something.", { cause });
+ * }
+ * ```
+ * More information about the EcmaScript proposal that made this possible:
+ * https://github.com/tc39/proposal-error-cause
+ *
+ * ## The Old Documentation Prior to the Deprecation:
  * ### STANDARD EXCEPTION HANDLING - EXAMPLE WITH RE-THROW:
  *
  * Use the this utility function and pass in any throwable of whatever type and format
@@ -77,6 +96,7 @@ import { coerceUnknownToError } from "./coerce-unknown-to-error";
  *    return result; // 42
  *  }
  * ```
+ * @deprecated
  *
  * @param message The contextual information that will be passed into the
  * constructor of the returned {@link RuntimeError} instance.
@@ -93,9 +113,28 @@ export function createRuntimeErrorWithCause(
 }
 
 /**
+ * ## DEPRECATED
+ *
+ * Instead of relying on this function, in the future, use the new `cause`
+ * property of the built-in `Error` type in combination
+ * with the `asError(unknown)` utility function:
+ * ```typescript
+ * import { asError } from "@hyperledger/cactus-common";
+ *
+ * try {
+ *   await performSomeImportantOperation();
+ * } catch (ex: unknown) {
+ *  const cause = asError(ex);
+ *   throw new Error("Something went wrong while doing something.", { cause });
+ * }
+ * ```
+ * More information about the EcmaScript proposal that made this possible:
+ * https://github.com/tc39/proposal-error-cause
+ *
  * An alias to the `createRuntimeErrorWithCause` function for those prefering
  * a shorter utility for their personal style.
  *
+ * @deprecated
  * @see {@link createRuntimeErrorWithCause}
  * @returns `RuntimeError`
  */

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,13 +9,10 @@
     },
     /* Basic Options */
     "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2017", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "ES2022", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "CommonJS", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": [
-      "es2015",
-      "es2016",
-      "es2017",
-      "es2019",
+      "ES2022",
       "dom"
     ], /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -172,13 +172,10 @@
   ],
   "compilerOptions": {
     "incremental": true,
-    "target": "ES2017",
+    "target": "ES2022",
     "module": "Node16",
     "lib": [
-      "es2015",
-      "es2016",
-      "es2017",
-      "es2019",
+      "ES2022",
       "dom"
     ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Project-wide upgrade to Typescript target of ES2022 so that we can use
the new Error APIs.

Wherever possible we should now use the new `cause`
property of the built-in `Error` type in combination
with the `asError(unknown)` utility function:
```typescript
import { asError } from "@hyperledger/cactus-common";

try {
    await performSomeImportantOperation();
} catch (ex: unknown) {
    const cause = asError(ex);
    throw new Error("Something went wrong while doing something.", { cause });
}
```
More information about the EcmaScript proposal that made this possible:
https://github.com/tc39/proposal-error-cause

Fixes #3592

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.