### PR TITLE
ci(github): pr parity to include hyphen

### DIFF
--- a/.github/workflows/pr-commit-parity.yaml
+++ b/.github/workflows/pr-commit-parity.yaml
@@ -2,9 +2,6 @@
 name: PR - Commit Parity
 on: [pull_request]
 
-env:
-  NODEJS_VERSION: v18.18.2
-
 jobs:
   pr-commit-parity:
     name: PR and Commit messages Parity

--- a/tools/pr-commit-parity.js
+++ b/tools/pr-commit-parity.js
@@ -53,7 +53,6 @@ export async function fetchJsonFromUrl(url) {
 const PULL_REQ_REQUIREMENTS_REGEX = /\*\*Pull\sRequest\sRequirements(.|\n)*/gim;
 const SIGNED_OFF_REGEX = /(")*Signed-off-by:(.|\s)*/gim;
 const COMMIT_TITLE_REGEX = /^.*$/m;
-const HYPHEN_REGEX = /(-)+/gm;
 const BACKTICK_REGEX = /`+/gm;
 const COMMIT_TO_BE_REVIEWED_REGEX = /("#*\s*Commit\sto\sbe\sreviewed)/gim;
 const HYPERLEDGER_REFERENCE_REGEX = /hyperledger#/gm;
@@ -80,7 +79,6 @@ commitMessagesMetadata.forEach((commitMessageMetadata) => {
   commitMessageList.push(
     commitMessageMetadata["commit"]["message"]
       .replace(SIGNED_OFF_REGEX, "")
-      .replace(HYPHEN_REGEX, "")
       .replace(BACKTICK_REGEX, "")
       .replace(HYPERLEDGER_REFERENCE_REGEX, "#")
       .replace(WHITESPACES_HARDCODED_REGEX, "")
@@ -92,7 +90,6 @@ let prBodyStriped = prBodyRaw
   .replace(PULL_REQ_REQUIREMENTS_REGEX, "")
   .replace(WHITESPACES_HARDCODED_REGEX, "\n")
   .replace(SIGNED_OFF_REGEX, "")
-  .replace(HYPHEN_REGEX, "")
   .replace(BACKTICK_REGEX, "")
   .replace(HYPERLEDGER_REFERENCE_REGEX, "#")
   .replace(COMMIT_TO_BE_REVIEWED_REGEX, "")


### PR DESCRIPTION
## Commit to be reviewed

ci(github): pr parity to include hyphen

    Primary Changes
    ----------------
    1. Updated the code to remove the hyphen regex from the pr-commit parity script
    2. Removed an unused var from the workflow

Fixes #3557

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.