### PR TITLE
chore: install secret detection on pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,15 +170,20 @@ To protect the Hyperledger Cacti source code, GitHub pull requests are accepted 
    git rebase main
    # Happy coding !
    ```
-5. Commit changes to your branch.
+5. Install the git hook scripts. (This command should only be run once)
+   ```
+   yarn run tools:install-pre-commit-secret-detection
+   # Now pre-commit will run automatically on git commit
+   ```
+6. Commit changes to your branch.
    ```
    # Commit and push your changes to your fork
    git add -A
    git commit -s -m "<type>[optional scope]: <description>"
    git push origin <newfeature>
    ```
-6. Once you've committed and pushed all of your changes to GitHub, go to the page for your fork on GitHub, select your development branch, and click the pull request button.
-7. Repeat step 3 to 6 when you need to prepare posting new pull request.
+7. Once you've committed and pushed all of your changes to GitHub, go to the page for your fork on GitHub, select your development branch, and click the pull request button.
+8. Repeat step 3 to 7 when you need to prepare posting new pull request.
 
 NOTE: Once you submitted pull request to Cacti repository, step 6 is not necessary when you made further changes with `git commit --amend` since your amends will be sent automatically.
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "set-yarn-version": "yarn set version stable",
     "enable-corepack": "npm i -g corepack && corepack enable && corepack prepare yarn@4.3.1 --activate",
     "custom-checks": "TS_NODE_PROJECT=./tools/tsconfig.json node --trace-deprecation --experimental-modules --abort-on-uncaught-exception --loader ts-node/esm --experimental-specifier-resolution=node ./tools/custom-checks/run-custom-checks.ts",
+    "tools:install-pre-commit-secret-detection": "pre-commit install && pre-commit autoupdate",
+    "tools:uninstall-pre-commit-secret-detection": "pre-commit uninstall",
     "tools:validate-bundle-names": "TS_NODE_PROJECT=./tools/tsconfig.json node --trace-deprecation --experimental-modules --abort-on-uncaught-exception --loader ts-node/esm --experimental-specifier-resolution=node ./tools/validate-bundle-names.js",
     "tools:bump-openapi-spec-dep-versions": "TS_NODE_PROJECT=./tools/tsconfig.json node --trace-deprecation --experimental-modules --abort-on-uncaught-exception --loader ts-node/esm --experimental-specifier-resolution=node ./tools/bump-openapi-spec-dep-versions.ts",
     "tools:bundle-open-api-tpl-files": "TS_NODE_PROJECT=./tools/tsconfig.json node --trace-deprecation --experimental-modules --abort-on-uncaught-exception --loader ts-node/esm --experimental-specifier-resolution=node ./tools/bundle-open-api-tpl-files.ts",


### PR DESCRIPTION
## Commit to be reviewed

chore: install secret detection on pre-commit hooks
```
Primary Changes
----------------
1. Installed gitleaks for secret detection.
2. This pre-commit checker detects any secrets
or crypto so that it doesn't get pushed to
the github repo.
3. Added script to run install and uninstall
the pre-commit hooks in package.json

```
Fixes #2290

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.