### PR TITLE
test(connector-besu): migrate get-past-logs-endpoint to Jest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2043,7 +2043,7 @@ jobs:
       JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ctp-ledger-connector-besu
       JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
-        --files={./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-past-logs-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts}
+        --files={./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
     runs-on: ubuntu-22.04
     steps:

--- a/.taprc
+++ b/.taprc
@@ -22,7 +22,6 @@ files:
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts
-  - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-past-logs-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,7 +34,6 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts`,
-    `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-past-logs-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts`,

--- a/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-past-logs-endpoint.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-past-logs-endpoint.test.ts
@@ -1,12 +1,13 @@
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 
 import { v4 as uuidv4 } from "uuid";
 import { createServer } from "http";
+
 import KeyEncoder from "key-encoder";
 import { AddressInfo } from "net";
+
 import Web3 from "web3";
 import Web3JsQuorum, { IWeb3Quorum } from "web3js-quorum";
-
 import {
   ApiServer,
   AuthorizationProtocol,
@@ -16,13 +17,12 @@ import {
   Secp256k1Keys,
   KeyFormat,
   LogLevelDesc,
+  LoggerProvider,
 } from "@hyperledger/cactus-common";
-
 import {
   BesuTestLedger,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
-
 import {
   BesuApiClientOptions,
   BesuApiClient,
@@ -30,145 +30,150 @@ import {
   PluginLedgerConnectorBesu,
   GetPastLogsV1Request,
 } from "@hyperledger/cactus-plugin-ledger-connector-besu";
-
 import { PluginRegistry } from "@hyperledger/cactus-core";
-
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 
 const testCase = "API client can call getPastLogs via network";
 const logLevel: LogLevelDesc = "TRACE";
 
-test("BEFORE " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
-  t.end();
-});
-
-test(testCase, async (t: Test) => {
-  const keyEncoder: KeyEncoder = new KeyEncoder("secp256k1");
-  const keychainId = uuidv4();
-  const keychainRef = uuidv4();
-
-  const { privateKey } = Secp256k1Keys.generateKeyPairsBuffer();
-  const keyHex = privateKey.toString("hex");
-  const pem = keyEncoder.encodePrivate(keyHex, KeyFormat.Raw, KeyFormat.PEM);
-
-  const keychain = new PluginKeychainMemory({
-    backend: new Map([[keychainRef, pem]]),
-    keychainId,
-    logLevel,
-    instanceId: uuidv4(),
+describe("API client can call getPastLogs via network", () => {
+  const log = LoggerProvider.getOrCreate({
+    label: "get-past-logs-endpoint.test.ts",
+    level: logLevel,
   });
 
-  const httpServer1 = createServer();
-  await new Promise((resolve, reject) => {
-    httpServer1.once("error", reject);
-    httpServer1.once("listening", resolve);
-    httpServer1.listen(0, "127.0.0.1");
-  });
-  const addressInfo1 = httpServer1.address() as AddressInfo;
-  t.comment(`HttpServer1 AddressInfo: ${JSON.stringify(addressInfo1)}`);
-  const node1Host = `http://${addressInfo1.address}:${addressInfo1.port}`;
-  t.comment(`Cactus Node 1 Host: ${node1Host}`);
+  const containerImageVersion = "2021-08-24--feat-1244";
+  const containerImageName =
+    "ghcr.io/hyperledger/cactus-besu-21-1-6-all-in-one";
+  const besuOptions = { containerImageName, containerImageVersion };
+  const besuTestLedger = new BesuTestLedger(besuOptions);
 
-  const besuTestLedger = new BesuTestLedger();
-  await besuTestLedger.start();
+  let apiServer: ApiServer;
+  let node1Host: string;
+  let Web3Quorum: IWeb3Quorum;
+  let besuPrivateKey: string;
+  let web3: Web3;
+
+  beforeAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).toResolve();
+
+    await besuTestLedger.start();
+
+    const keyEncoder: KeyEncoder = new KeyEncoder("secp256k1");
+    const keychainId = uuidv4();
+    const keychainRef = uuidv4();
+    const { privateKey } = Secp256k1Keys.generateKeyPairsBuffer();
+    const keyHex = privateKey.toString("hex");
+    const pem = keyEncoder.encodePrivate(keyHex, KeyFormat.Raw, KeyFormat.PEM);
+    const keychain = new PluginKeychainMemory({
+      backend: new Map([[keychainRef, pem]]),
+      keychainId,
+      logLevel,
+      instanceId: uuidv4(),
+    });
+
+    const httpServer1 = createServer();
+    await new Promise((resolve, reject) => {
+      httpServer1.once("error", reject);
+      httpServer1.once("listening", resolve);
+      httpServer1.listen(0, "127.0.0.1");
+    });
+
+    const addressInfo1 = httpServer1.address() as AddressInfo;
+    log.debug(`HttpServer1 AddressInfo: ${JSON.stringify(addressInfo1)}`);
+    node1Host = `http://${addressInfo1.address}:${addressInfo1.port}`;
+    log.debug(`Cactus Node 1 Host: ${node1Host}`);
+
+    const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
+    const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
+
+    const pluginRegistry = new PluginRegistry({ plugins: [keychain] });
+    const options: IPluginLedgerConnectorBesuOptions = {
+      instanceId: uuidv4(),
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      pluginRegistry,
+      logLevel,
+    };
+
+    const pluginValidatorBesu = new PluginLedgerConnectorBesu(options);
+
+    const configService = new ConfigService();
+    const apiServerOptions = await configService.newExampleConfig();
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = addressInfo1.port;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.crpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
+    const config =
+      await configService.newExampleConfigConvict(apiServerOptions);
+    pluginRegistry.add(pluginValidatorBesu);
+
+    apiServer = new ApiServer({
+      httpServerApi: httpServer1,
+      config: config.getProperties(),
+      pluginRegistry,
+    });
+
+    await apiServer.start();
+
+    const web3Provider = new Web3.providers.HttpProvider(rpcApiHttpHost);
+    web3 = new Web3(web3Provider);
+    Web3Quorum = Web3JsQuorum(web3);
+    const besuKeyPair = await besuTestLedger.getBesuKeyPair();
+    besuPrivateKey = besuKeyPair.privateKey.toLowerCase().startsWith("0x")
+      ? besuKeyPair.privateKey.substring(2)
+      : besuKeyPair.privateKey;
+  });
+
+  afterAll(async () => {
+    await apiServer.shutdown();
+  });
 
   const tearDown = async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
   };
 
-  test.onFinish(tearDown);
-  const testAccount = await besuTestLedger.createEthTestAccount();
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
+  afterAll(tearDown);
 
-  // 2. Instantiate plugin registry which will provide the web service plugin with the key value storage plugin
-  const pluginRegistry = new PluginRegistry({ plugins: [keychain] });
-
-  // 3. Instantiate the web service consortium plugin
-  const options: IPluginLedgerConnectorBesuOptions = {
-    instanceId: uuidv4(),
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    pluginRegistry,
-    logLevel,
-  };
-  const pluginValidatorBesu = new PluginLedgerConnectorBesu(options);
-
-  // 4. Create the API Server object that we embed in this test
-  const configService = new ConfigService();
-  const apiServerOptions = await configService.newExampleConfig();
-  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
-  apiServerOptions.configFile = "";
-  apiServerOptions.apiCorsDomainCsv = "*";
-  apiServerOptions.apiPort = addressInfo1.port;
-  apiServerOptions.cockpitPort = 0;
-  apiServerOptions.grpcPort = 0;
-  apiServerOptions.crpcPort = 0;
-  apiServerOptions.apiTlsEnabled = false;
-  const config = await configService.newExampleConfigConvict(apiServerOptions);
-
-  pluginRegistry.add(pluginValidatorBesu);
-
-  const apiServer = new ApiServer({
-    httpServerApi: httpServer1,
-    config: config.getProperties(),
-    pluginRegistry,
+  afterAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).toResolve();
   });
 
-  // 5. make sure the API server is shut down when the testing if finished.
-  test.onFinish(() => apiServer.shutdown());
+  test(testCase, async () => {
+    const orionKeyPair = await besuTestLedger.getOrionKeyPair();
+    const contractOptions = {
+      data: `0x123`,
+      // privateFrom : Orion public key of the sender.
+      privateFrom: orionKeyPair.publicKey,
+      // privateFor : Orion public keys of recipients or privacyGroupId: Privacy group to receive the transaction
+      privateFor: [orionKeyPair.publicKey],
+      // privateKey: Ethereum private key with which to sign the transaction.
+      privateKey: besuPrivateKey,
+    };
 
-  // 6. Start the API server which is now listening on port A and it's healthcheck works through the main SDK
-  await apiServer.start();
+    const transactionHash =
+      await Web3Quorum.priv.generateAndSendRawTransaction(contractOptions);
+    await web3.eth.getTransaction(transactionHash);
 
-  // 7. Instantiate the main SDK dynamically with whatever port the API server ended up bound to (port 0)
-  t.comment(`AddressInfo: ${JSON.stringify(addressInfo1)}`);
+    const testAccount = await besuTestLedger.createEthTestAccount();
+    const request: GetPastLogsV1Request = {
+      address: testAccount.address,
+    };
 
-  const web3Provider = new Web3.providers.HttpProvider(rpcApiHttpHost);
-  const web3 = new Web3(web3Provider);
-  const Web3Quorum: IWeb3Quorum = Web3JsQuorum(web3);
+    const configuration = new BesuApiClientOptions({ basePath: node1Host });
+    const api = new BesuApiClient(configuration);
 
-  const orionKeyPair = await besuTestLedger.getOrionKeyPair();
-  const besuKeyPair = await besuTestLedger.getBesuKeyPair();
+    const res = await api.getPastLogsV1(request);
 
-  const besuPrivateKey = besuKeyPair.privateKey.toLowerCase().startsWith("0x")
-    ? besuKeyPair.privateKey.substring(2)
-    : besuKeyPair.privateKey; // besu node's private key
-
-  const contractOptions = {
-    data: `0x123`,
-    // privateFrom : Orion public key of the sender.
-    privateFrom: orionKeyPair.publicKey,
-    // privateFor : Orion public keys of recipients or privacyGroupId: Privacy group to receive the transaction
-    privateFor: [orionKeyPair.publicKey],
-    // privateKey: Ethereum private key with which to sign the transaction.
-    privateKey: besuPrivateKey,
-  };
-
-  const transactionHash =
-    await Web3Quorum.priv.generateAndSendRawTransaction(contractOptions);
-
-  await web3.eth.getTransaction(transactionHash);
-
-  const request: GetPastLogsV1Request = {
-    address: testAccount.address,
-  };
-
-  const configuration = new BesuApiClientOptions({ basePath: node1Host });
-  const api = new BesuApiClient(configuration);
-
-  const res = await api.getPastLogsV1(request);
-  // const { } = res;
-  t.ok(res, "API response object is truthy");
-  t.ok(res.data.logs, "Response.logs is truthy ok");
-  t.true(Array.isArray(res.data.logs), "Response.logs is Array ok");
-});
-
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
-  t.end();
+    expect(res).toBeTruthy();
+    expect(res.data.logs).toBeTruthy();
+    expect(res.data.logs).toBeArray();
+  });
 });


### PR DESCRIPTION
## Commit to be reviewed

test(connector-besu): migrate get-past-logs-endpoint to Jest 

     Primary Changes
     ------------------
     1. Updated the migrate get-past-logs-endpoint test 
         to use Jest
     2. Updated the ci.yaml TAPE_TEST_PATTERN to
         incorporate the same

Fixes #3505

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.