### PR TITLE
ci(check-ci-skip): fix commitMessagesMetadata.forEach is not a function

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,12 @@ env:
 jobs:
   ActionLint:
     needs: check-ci-skip
+    if: needs.check-ci-skip.outputs.should_skip == 'false'
     uses: ./.github/workflows/actionlint.yaml
   DCI-Lint:
     name: DCI-Lint
     needs: check-ci-skip
+    if: needs.check-ci-skip.outputs.should_skip == 'false'
     runs-on: ubuntu-22.04
     steps:
       - id: lint-git-repo
@@ -33,13 +35,18 @@ jobs:
 
   check-ci-skip:
     runs-on: ubuntu-22.04
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Check CI Skip
-        run: node tools/ci-skip-for-maintainers.js ${{ github.event.pull_request.url }} ${{ github.event.pull_request.user.login }}
+        run: node tools/ci-skip-for-maintainers.js
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
 
   check-coverage:
     needs: check-ci-skip
+    if: needs.check-ci-skip.outputs.should_skip == 'false'
     outputs:
       run-coverage: ${{ steps.set-output.outputs.run-coverage }}
     runs-on: ubuntu-22.04
@@ -51,6 +58,7 @@ jobs:
 
   compute_changed_packages:
     needs: check-ci-skip
+    if: needs.check-ci-skip.outputs.should_skip == 'false'
     outputs:
       cmd-api-server-changed: ${{ steps.changes.outputs.cmd-api-server-changed }}
       plugin-ledger-connector-polkadot-changed: ${{ steps.changes.outputs.plugin-ledger-connector-polkadot-changed }}
@@ -187,6 +195,7 @@ jobs:
 
   build-dev:
     needs: check-ci-skip
+    if: needs.check-ci-skip.outputs.should_skip == 'false'
     continue-on-error: false
     env:
       DEV_BUILD_DISABLED: false


### PR DESCRIPTION
## Commit to be reviewed

ci(check-ci-skip): fix commitMessagesMetadata.forEach is not a function
```
Primary Changes
----------------
1. Changed the method in getting the commit
message from GitHub API to shell command to avoid
the rate limits in calling the API.
2. Same goes for the author of commit message,
we use shell command to fetch the username.
```
Fixes #3614

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.