### PR TITLE
ci(github): fix DAST scan besu connectivity

### DIFF
--- a/.github/workflows/.dast-nuclei-cmd-api-server.yaml
+++ b/.github/workflows/.dast-nuclei-cmd-api-server.yaml
@@ -41,9 +41,9 @@ jobs:
 
       - uses: actions/setup-go@v4.0.0
         with:
-          go-version: 1.17
+          go-version: 1.23
 
-      - run: go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@v2.7.3
+      - run: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.5
 
       - run: nuclei --version
 
@@ -88,11 +88,11 @@ jobs:
         run: jq '.plugins += [{ "packageName":"@hyperledger/cactus-plugin-ledger-connector-fabric", "type":"org.hyperledger.cactus.plugin_import_type.LOCAL", "action":"org.hyperledger.cactus.plugin_import_action.INSTALL",  "options":{ "packageSrc":"/home/runner/work/cacti/cacti/packages/cactus-plugin-ledger-connector-fabric/", "instanceId":"some-unique-fabric-connector-instance-id", "peerBinary":"/fabric-samples/bin/peer", "connectionProfile":"{}", "dockerBinary":"usr/local/bin/docker","cliContainerEnv":{"CORE_PEER_LOCALMSPID":"Org1MSP","CORE_PEER_ADDRESS":"peer0.org1.example.com:7051","CORE_PEER_MSPCONFIGPATH":"/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp","CORE_PEER_TLS_ROOTCERT_FILE":"/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt","ORDERER_TLS_ROOTCERT_FILE":"/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem"},"discoveryOptions":{"enabled":true,"asLocalhost":true}}}] ' .config.json > .config2.json && mv .config2.json .config.json
 
       - name: Install Besu connector into the API server
-        run: jq '.plugins += [{"packageName":"@hyperledger/cactus-plugin-ledger-connector-besu","type":"org.hyperledger.cactus.plugin_import_type.LOCAL","action":"org.hyperledger.cactus.plugin_import_action.INSTALL","options":{"packageSrc":"/home/runner/work/cacti/cacti/packages/cactus-plugin-ledger-connector-besu/", "rpcApiHttpHost":"http://localhost:8545", "rpcApiWsHost":"ws://localhost:8546", "instanceId":"some-unique-besu-connector-instance-id"}}]' .config.json > .config2.json && mv .config2.json .config.json
+        run: jq '.plugins += [{"packageName":"@hyperledger/cactus-plugin-ledger-connector-besu","type":"org.hyperledger.cactus.plugin_import_type.LOCAL","action":"org.hyperledger.cactus.plugin_import_action.INSTALL","options":{"packageSrc":"/home/runner/work/cacti/cacti/packages/cactus-plugin-ledger-connector-besu/", "rpcApiHttpHost":"http://127.0.0.1:8545", "rpcApiWsHost":"ws://127.0.0.1:8546", "instanceId":"some-unique-besu-connector-instance-id"}}]' .config.json > .config2.json && mv .config2.json .config.json
 
       - name: Run Besu all-in-one image
         run: |
-          docker run -d -p 0.0.0.0:8545:8545/tcp  -p 0.0.0.0:8546:8546/tcp  -p 0.0.0.0:8888:8888/tcp  -p 0.0.0.0:9001:9001/tcp  -p 0.0.0.0:9545:9545/tcp ghcr.io/hyperledger/cactus-besu-all-in-one:2022-04-14-dda3f00
+          docker run -d -p 0.0.0.0:8545:8545/tcp  -p 0.0.0.0:8546:8546/tcp  -p 0.0.0.0:8888:8888/tcp  -p 0.0.0.0:9001:9001/tcp  -p 0.0.0.0:9545:9545/tcp ghcr.io/hyperledger/cactus-besu-all-in-one:v2.0.0-rc.7
           until curl --fail -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' localhost:8545; do sleep 5;  done
 
       - name: Print API Server Config File - ./.config.json
@@ -114,11 +114,14 @@ jobs:
         with:
           build: yarn --version
           start: yarn start:api-server
-          command: "nuclei -update-templates --config=.nuclei-config.yaml --list=urls.txt --sarif-export ~/nuclei.sarif --output nuclei.log"
+          command: "nuclei -version"
           command-windows: echo "The project build is not supported on the Windows operating system. Please use Linux or macOS"
           wait-on: "https://localhost:4000/api/v1/api-server/healthcheck"
           # wait for 10 minutes for the server to respond
           wait-on-timeout: 120
+      
+      - name: Run the dast nuclei scan
+        run: "nuclei -list=urls.txt -dast -severity=high,critical -sarif-export ~/nuclei.sarif -output=nuclei.log"
 
       - name: GitHub Workflow artifacts
         uses: actions/upload-artifact@v3.0.0


### PR DESCRIPTION
## Commit to be reviewed

ci(github): fix DAST scan besu connectivity

    Primary Changes
    --------------
    1. Hardcoded the localhost to 127.0.0.1 for the config.json file
        required to spin up cactus-cmd-api-server

    Secondary Changes
    -----------------
    3. Updated the verion of besu AIO
    4. Updated the version of nuclei

    Changes required to incorporate 3)
    ---------------------------------
    5. Updated the go version

Fixes #3596

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.