### PR TITLE
test(connector-besu): jest migrate get-transaction-endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2049,7 +2049,7 @@ jobs:
       JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ctp-ledger-connector-besu
       JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
-        --files={./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts}
+        --files={./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
     runs-on: ubuntu-22.04
     steps:

--- a/.taprc
+++ b/.taprc
@@ -22,7 +22,6 @@ files:
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts
-  - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts
   - ./packages/cactus-plugin-keychain-vault/src/test/typescript/integration/cactus-keychain-vault-server.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,6 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts`,
-    `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts`,
     `./packages/cactus-plugin-keychain-vault/src/test/typescript/integration/cactus-keychain-vault-server.test.ts`,

--- a/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts
@@ -1,9 +1,11 @@
-import test, { Test } from "tape-promise/tape";
+import "jest-extended";
 
 import { v4 as uuidv4 } from "uuid";
 import { createServer } from "http";
+
 import KeyEncoder from "key-encoder";
 import { AddressInfo } from "net";
+
 import Web3 from "web3";
 import Web3JsQuorum, { IWeb3Quorum } from "web3js-quorum";
 
@@ -17,12 +19,11 @@ import {
   KeyFormat,
   LogLevelDesc,
 } from "@hyperledger/cactus-common";
-
 import {
   BesuTestLedger,
   pruneDockerAllIfGithubAction,
+  IKeyPair,
 } from "@hyperledger/cactus-test-tooling";
-
 import {
   BesuApiClientOptions,
   BesuApiClient,
@@ -32,148 +33,132 @@ import {
 } from "@hyperledger/cactus-plugin-ledger-connector-besu";
 
 import { PluginRegistry } from "@hyperledger/cactus-core";
-
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 
-const testCase = "API client can call get-transaction via network";
+const testCase = "Test get transaction endpoint";
 const logLevel: LogLevelDesc = "TRACE";
 
-test("BEFORE " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
-  t.end();
-});
-
-test(testCase, async (t: Test) => {
-  const keyEncoder: KeyEncoder = new KeyEncoder("secp256k1");
-  const keychainId = uuidv4();
-  const keychainRef = uuidv4();
-
-  const { privateKey } = Secp256k1Keys.generateKeyPairsBuffer();
-  const keyHex = privateKey.toString("hex");
-  const pem = keyEncoder.encodePrivate(keyHex, KeyFormat.Raw, KeyFormat.PEM);
-
-  const keychain = new PluginKeychainMemory({
-    backend: new Map([[keychainRef, pem]]),
-    keychainId,
-    logLevel,
-    instanceId: uuidv4(),
-  });
-
-  const httpServer1 = createServer();
-  await new Promise((resolve, reject) => {
-    httpServer1.once("error", reject);
-    httpServer1.once("listening", resolve);
-    httpServer1.listen(0, "127.0.0.1");
-  });
-  const addressInfo1 = httpServer1.address() as AddressInfo;
-  t.comment(`HttpServer1 AddressInfo: ${JSON.stringify(addressInfo1)}`);
-  const node1Host = `http://${addressInfo1.address}:${addressInfo1.port}`;
-  t.comment(`Cactus Node 1 Host: ${node1Host}`);
-
+describe(testCase, () => {
   const besuTestLedger = new BesuTestLedger();
-  await besuTestLedger.start();
+  let apiServer: ApiServer;
 
-  const tearDown = async () => {
+  beforeAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
+    await besuTestLedger.start();
+  });
+
+  afterAll(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
-  };
-
-  test.onFinish(tearDown);
-
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
-
-  // 2. Instantiate plugin registry which will provide the web service plugin with the key value storage plugin
-  const pluginRegistry = new PluginRegistry({ plugins: [keychain] });
-
-  // 3. Instantiate the web service consortium plugin
-  const options: IPluginLedgerConnectorBesuOptions = {
-    instanceId: uuidv4(),
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    pluginRegistry,
-    logLevel,
-  };
-  const pluginValidatorBesu = new PluginLedgerConnectorBesu(options);
-
-  // 4. Create the API Server object that we embed in this test
-  const configService = new ConfigService();
-  const apiServerOptions = await configService.newExampleConfig();
-  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
-  apiServerOptions.configFile = "";
-  apiServerOptions.apiCorsDomainCsv = "*";
-  apiServerOptions.apiPort = addressInfo1.port;
-  apiServerOptions.cockpitPort = 0;
-  apiServerOptions.grpcPort = 0;
-  apiServerOptions.crpcPort = 0;
-  apiServerOptions.apiTlsEnabled = false;
-  const config = await configService.newExampleConfigConvict(apiServerOptions);
-
-  pluginRegistry.add(pluginValidatorBesu);
-
-  const apiServer = new ApiServer({
-    httpServerApi: httpServer1,
-    config: config.getProperties(),
-    pluginRegistry,
+    await apiServer.shutdown();
   });
 
-  // 5. make sure the API server is shut down when the testing if finished.
-  test.onFinish(() => apiServer.shutdown());
+  test(testCase, async () => {
+    const keyEncoder: KeyEncoder = new KeyEncoder("secp256k1");
+    const keychainId = uuidv4();
+    const keychainRef = uuidv4();
 
-  // 6. Start the API server which is now listening on port A and it's healthcheck works through the main SDK
-  await apiServer.start();
+    const { privateKey } = Secp256k1Keys.generateKeyPairsBuffer();
+    const keyHex = privateKey.toString("hex");
+    const pem = keyEncoder.encodePrivate(keyHex, KeyFormat.Raw, KeyFormat.PEM);
 
-  // 7. Instantiate the main SDK dynamically with whatever port the API server ended up bound to (port 0)
-  t.comment(`AddressInfo: ${JSON.stringify(addressInfo1)}`);
+    const keychain = new PluginKeychainMemory({
+      backend: new Map([[keychainRef, pem]]),
+      keychainId,
+      logLevel,
+      instanceId: uuidv4(),
+    });
 
-  const web3Provider = new Web3.providers.HttpProvider(rpcApiHttpHost);
-  const web3 = new Web3(web3Provider);
-  const web3JsQuorum: IWeb3Quorum = Web3JsQuorum(web3);
+    const pluginRegistry = new PluginRegistry({ plugins: [keychain] });
+    const httpServer1 = createServer();
 
-  const orionKeyPair = await besuTestLedger.getOrionKeyPair();
-  const besuKeyPair = await besuTestLedger.getBesuKeyPair();
+    await new Promise((resolve, reject) => {
+      httpServer1.once("error", reject);
+      httpServer1.once("listening", resolve);
+      httpServer1.listen(0, "127.0.0.1");
+    });
 
-  const besuPrivateKey = besuKeyPair.privateKey.toLowerCase().startsWith("0x")
-    ? besuKeyPair.privateKey.substring(2)
-    : besuKeyPair.privateKey; // besu node's private key
+    const addressInfo1 = httpServer1.address() as AddressInfo;
+    console.log(`HttpServer1 AddressInfo: ${JSON.stringify(addressInfo1)}`);
 
-  const contractOptions = {
-    data: `0x123`,
-    // privateFrom : Orion public key of the sender.
-    privateFrom: orionKeyPair.publicKey,
-    // privateFor : Orion public keys of recipients or privacyGroupId: Privacy group to receive the transaction
-    privateFor: [orionKeyPair.publicKey],
-    // privateKey: Ethereum private key with which to sign the transaction.
-    privateKey: besuPrivateKey,
-  };
+    const node1Host = `http://${addressInfo1.address}:${addressInfo1.port}`;
+    console.log(`Cactus Node 1 Host: ${node1Host}`);
 
-  const transactionHash =
-    await web3JsQuorum.priv.generateAndSendRawTransaction(contractOptions);
+    const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
+    const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
 
-  await web3.eth.getTransaction(transactionHash);
+    const options: IPluginLedgerConnectorBesuOptions = {
+      instanceId: uuidv4(),
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      pluginRegistry,
+      logLevel,
+    };
 
-  const request: GetTransactionV1Request = {
-    transactionHash: transactionHash,
-  };
+    const pluginValidatorBesu = new PluginLedgerConnectorBesu(options);
 
-  const configuration = new BesuApiClientOptions({ basePath: node1Host });
-  const api = new BesuApiClient(configuration);
+    const cfgSvc = new ConfigService();
+    const apiSrvOpts = await cfgSvc.newExampleConfig();
+    apiSrvOpts.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiSrvOpts.configFile = "";
+    apiSrvOpts.apiCorsDomainCsv = "*";
+    apiSrvOpts.apiPort = addressInfo1.port;
+    apiSrvOpts.cockpitPort = 0;
+    apiSrvOpts.grpcPort = 0;
+    apiSrvOpts.crpcPort = 0;
+    apiSrvOpts.apiTlsEnabled = false;
+    const config = await cfgSvc.newExampleConfigConvict(apiSrvOpts);
 
-  // Test for 200 valid response test case
-  const res = await api.getTransactionV1(request);
+    pluginRegistry.add(pluginValidatorBesu);
 
-  // const { } = res;
-  t.ok(res, "API response object is truthy");
-  t.ok(res.data.transaction, "Transaction is truthy ok");
-  t.true(
-    typeof res.data.transaction === "object",
-    "Response.transaction is OK",
-  );
-});
+    apiServer = new ApiServer({
+      httpServerApi: httpServer1,
+      config: config.getProperties(),
+      pluginRegistry,
+    });
 
-test("AFTER " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning didn't throw OK");
-  t.end();
+    await apiServer.start();
+
+    console.log(`AddressInfo: ${JSON.stringify(addressInfo1)}`);
+
+    const web3Provider = new Web3.providers.HttpProvider(rpcApiHttpHost);
+    const web3 = new Web3(web3Provider);
+    const web3JsQuorum: IWeb3Quorum = Web3JsQuorum(web3);
+
+    const orionKeyPair: IKeyPair = await besuTestLedger.getOrionKeyPair();
+    const besuKeyPair = await besuTestLedger.getBesuKeyPair();
+
+    const besuPrivateKey = besuKeyPair.privateKey.toLowerCase().startsWith("0x")
+      ? besuKeyPair.privateKey.substring(2)
+      : besuKeyPair.privateKey; // besu node's private key
+
+    const contractOptions = {
+      data: `0x123`,
+      // privateFrom : Orion public key of the sender.
+      privateFrom: orionKeyPair.publicKey,
+      // privateFor : Orion public keys of recipients or privacyGroupId: Privacy group to receive the transaction
+      privateFor: [orionKeyPair.publicKey],
+      // privateKey: Ethereum private key with which to sign the transaction.
+      privateKey: besuPrivateKey,
+    };
+
+    const transactionHash =
+      await web3JsQuorum.priv.generateAndSendRawTransaction(contractOptions);
+    await web3.eth.getTransaction(transactionHash);
+
+    const request: GetTransactionV1Request = {
+      transactionHash: transactionHash,
+    };
+
+    const configuration = new BesuApiClientOptions({ basePath: node1Host });
+    const api = new BesuApiClient(configuration);
+
+    // Test for 200 valid response test case
+    const res = await api.getTransactionV1(request);
+
+    expect(res).toBeTruthy();
+    expect(res.data.transaction).toBeTruthy();
+    expect(res.data.transaction).toBeObject();
+  });
 });


### PR DESCRIPTION
Primary Changes:

packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/
integration/plugin-validator-besu/get-transaction-endpoint.test.ts

Fixes: #3539

Co-authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Signed-off-by: Udhayakumari <62878965+Udhayakumari@users.noreply.github.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.