### PR TITLE
ci(release): add sigstore npm integration through --provenance

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   build-and-publish-packages:
     runs-on: ubuntu-22.04
+    permissions: 
+      id-token: write
     steps:
       - name: Print Workflow inputs.GIT_TAG_TO_PUBLISH
         run: |
@@ -58,6 +60,7 @@ jobs:
       - name: lerna-publish-npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: |
           git config --global user.email "npm-ci@hyperledger.org"
           git config --global user.name "hyperledger-ghci"

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -19,6 +19,8 @@ jobs:
 
   build-and-publish-packages:
     runs-on: ubuntu-22.04
+    permissions: 
+      id-token: write
     steps:
     - uses: actions/checkout@v4.1.7
       with:
@@ -28,7 +30,7 @@ jobs:
       with:
         always-auth: true
         node-version: ${{ env.NODEJS_VERSION }}
-        registry-url: 'https://registry.npmjs.org'
+        registry-url: 'https://registry.npmjs.org/'
     - name: ./tools/ci.sh
       run: ./tools/ci.sh
       env:
@@ -39,6 +41,7 @@ jobs:
     - name: lerna-publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_CONFIG_PROVENANCE: true
       run: |
         git config --global user.email "npm-ci@hyperledger.org"
         git config --global user.name "hyperledger-ghci"


### PR DESCRIPTION
## Commit to be reviewed
---
ci(release): add sigstore npm integration through --provenance
```
Primary Changes
----------------
1. Added provenance config to the publish workflows.
```
Fixes #2623

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.