### PR TITLE
chore(docs): fix packagename ref in openapi doc generation

### DIFF
--- a/docs/scripts/publish_openapi.py
+++ b/docs/scripts/publish_openapi.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import re
 import subprocess
 import json
 import shutil
@@ -65,7 +66,7 @@ for package in package_list:
     for openapi_file in get_openapi_files(package['location']):
         if not package_group in apis_by_group:
             apis_by_group[package_group] = []
-        package_basename = package['name'].replace('@hyperledger/','')
+        package_basename = re.sub(r'@.*\/', '', package['name'])
         publish_openapi(package_basename, openapi_file)
         print(f"{package_group} : {package_basename}")
         apis_by_group[package_group].append(package_basename)


### PR DESCRIPTION
Primary Change: The openapi doc generation script had a reference to the @hyperledger package prefix hardcoded.

This meant that packages that were updated to @hyperledger-cacti still had an ampersand in their path, resulting in 
them not being included in the generated documentation.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.