### PR TITLE
fix(connector-besu): set contract bytecode field's max length to 49154

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/api/openapi.yaml
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/api/openapi.yaml
@@ -1041,8 +1041,10 @@ components:
           $ref: '#/components/schemas/Web3SigningCredential'
         bytecode:
           description: See https://ethereum.stackexchange.com/a/47556 regarding the
-            maximum length of the bytecode
-          maxLength: 24576
+            maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex
+            stores each byte in 2 characters and that there is a 0x prefix (2 characters)
+            which does not count towards the EVM 24576 bytecode limit.
+          maxLength: 49154
           minLength: 1
           nullable: false
           type: string
@@ -1117,8 +1119,10 @@ components:
           $ref: '#/components/schemas/Web3SigningCredential'
         bytecode:
           description: See https://ethereum.stackexchange.com/a/47556 regarding the
-            maximum length of the bytecode
-          maxLength: 24576
+            maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex
+            stores each byte in 2 characters and that there is a 0x prefix (2 characters)
+            which does not count towards the EVM 24576 bytecode limit.
+          maxLength: 49154
           minLength: 1
           nullable: false
           type: string

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/model_deploy_contract_solidity_bytecode_no_keychain_v1_request.go
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/model_deploy_contract_solidity_bytecode_no_keychain_v1_request.go
@@ -25,7 +25,7 @@ type DeployContractSolidityBytecodeNoKeychainV1Request struct {
 	ContractAbi []interface{} `json:"contractAbi"`
 	ConstructorArgs []interface{} `json:"constructorArgs"`
 	Web3SigningCredential Web3SigningCredential `json:"web3SigningCredential"`
-	// See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode
+	// See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit.
 	Bytecode string `json:"bytecode"`
 	Gas *float32 `json:"gas,omitempty"`
 	GasPrice *string `json:"gasPrice,omitempty"`

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/model_deploy_contract_solidity_bytecode_v1_request.go
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/go/generated/openapi/go-client/model_deploy_contract_solidity_bytecode_v1_request.go
@@ -25,7 +25,7 @@ type DeployContractSolidityBytecodeV1Request struct {
 	ContractAbi []interface{} `json:"contractAbi"`
 	ConstructorArgs []interface{} `json:"constructorArgs"`
 	Web3SigningCredential Web3SigningCredential `json:"web3SigningCredential"`
-	// See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode
+	// See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit.
 	Bytecode string `json:"bytecode"`
 	// The keychainId for retrieve the contracts json.
 	KeychainId string `json:"keychainId"`

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json
@@ -731,8 +731,8 @@
             "type": "string",
             "nullable": false,
             "minLength": 1,
-            "maxLength": 24576,
-            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode"
+            "maxLength": 49154,
+            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit."
           },
           "keychainId": {
             "type": "string",
@@ -798,8 +798,8 @@
             "type": "string",
             "nullable": false,
             "minLength": 1,
-            "maxLength": 24576,
-            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode"
+            "maxLength": 49154,
+            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit."
           },
           "gas": {
             "type": "number",

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.tpl.json
@@ -731,8 +731,8 @@
             "type": "string",
             "nullable": false,
             "minLength": 1,
-            "maxLength": 24576,
-            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode"
+            "maxLength": 49154,
+            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit."
           },
           "keychainId": {
             "type": "string",
@@ -798,8 +798,8 @@
             "type": "string",
             "nullable": false,
             "minLength": 1,
-            "maxLength": 24576,
-            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode"
+            "maxLength": 49154,
+            "description": "See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit."
           },
           "gas": {
             "type": "number",

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/proto/generated/openapi/models/deploy_contract_solidity_bytecode_no_keychain_v1_request_pb.proto
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/proto/generated/openapi/models/deploy_contract_solidity_bytecode_no_keychain_v1_request_pb.proto
@@ -29,7 +29,7 @@ message DeployContractSolidityBytecodeNoKeychainV1RequestPB {
 
   Web3SigningCredentialPB web3SigningCredential = 451211679;
 
-  // See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode
+  // See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit.
   string bytecode = 256554254;
 
   float gas = 102105;

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/proto/generated/openapi/models/deploy_contract_solidity_bytecode_v1_request_pb.proto
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/proto/generated/openapi/models/deploy_contract_solidity_bytecode_v1_request_pb.proto
@@ -29,7 +29,7 @@ message DeployContractSolidityBytecodeV1RequestPB {
 
   Web3SigningCredentialPB web3SigningCredential = 451211679;
 
-  // See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode
+  // See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit.
   string bytecode = 256554254;
 
   // The keychainId for retrieve the contracts json.

--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -176,7 +176,7 @@ export interface DeployContractSolidityBytecodeNoKeychainV1Request {
      */
     'web3SigningCredential': Web3SigningCredential;
     /**
-     * See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode
+     * See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit.
      * @type {string}
      * @memberof DeployContractSolidityBytecodeNoKeychainV1Request
      */
@@ -237,7 +237,7 @@ export interface DeployContractSolidityBytecodeV1Request {
      */
     'web3SigningCredential': Web3SigningCredential;
     /**
-     * See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode
+     * See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode. 2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit.
      * @type {string}
      * @memberof DeployContractSolidityBytecodeV1Request
      */


### PR DESCRIPTION
Prior to this commit the Besu connector's API validated requests when deploying solidity
contracts via their bytecode such that the length of the bytecode parameter
cannot be longer than 24576 characters, but instead it should have an upper limit of
49154 characters because each byte is represented as two characters in hex.

See https://ethereum.stackexchange.com/a/47556 regarding the maximum length of the bytecode.
2 + (24576 * 2) = 49154 meaning that hex stores each byte in 2 characters and that
there is a 0x prefix (2 characters) which does not count towards the EVM 24576 bytecode limit."

Fixes #3636

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.