### PR TITLE
feat(cactus-core-api): add Ethereum ledger type

### DIFF
--- a/packages/cacti-plugin-consortium-static/src/main/json/openapi.json
+++ b/packages/cacti-plugin-consortium-static/src/main/json/openapi.json
@@ -131,6 +131,7 @@
           "BESU_2X",
           "BURROW_0X",
           "CORDA_4X",
+          "ETHEREUM",
           "FABRIC_2",
           "SAWTOOTH_1X"
         ]

--- a/packages/cacti-plugin-consortium-static/src/main/json/openapi.tpl.json
+++ b/packages/cacti-plugin-consortium-static/src/main/json/openapi.tpl.json
@@ -131,6 +131,7 @@
           "BESU_2X",
           "BURROW_0X",
           "CORDA_4X",
+          "ETHEREUM",
           "FABRIC_2",
           "SAWTOOTH_1X"
         ]

--- a/packages/cacti-plugin-consortium-static/src/main/kotlin/generated/openapi/kotlin-client/src/main/kotlin/org/openapitools/client/models/LedgerType.kt
+++ b/packages/cacti-plugin-consortium-static/src/main/kotlin/generated/openapi/kotlin-client/src/main/kotlin/org/openapitools/client/models/LedgerType.kt
@@ -22,7 +22,7 @@ import com.squareup.moshi.JsonClass
 /**
  * Enumerates the different ledger vendors and their major versions encoded within the name of the LedgerType. For example \"BESU_1X\" involves all of the [1.0.0;2.0.0) where 1.0.0 is included and anything up until, but not 2.0.0. See: https://stackoverflow.com/a/4396303/698470 for further explanation.
  *
- * Values: bESU1X,bESU2X,bURROW0X,cORDA4X,fABRIC2,sAWTOOTH1X
+ * Values: bESU1X,bESU2X,bURROW0X,cORDA4X,eTHEREUM,fABRIC2,sAWTOOTH1X
  */
 
 @JsonClass(generateAdapter = false)
@@ -39,6 +39,9 @@ enum class LedgerType(val value: kotlin.String) {
 
     @Json(name = "CORDA_4X")
     cORDA4X("CORDA_4X"),
+
+    @Json(name = "ETHEREUM")
+    eTHEREUM("ETHEREUM"),
 
     @Json(name = "FABRIC_2")
     fABRIC2("FABRIC_2"),

--- a/packages/cacti-plugin-consortium-static/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cacti-plugin-consortium-static/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -312,6 +312,7 @@ export const LedgerType = {
     Besu2X: 'BESU_2X',
     Burrow0X: 'BURROW_0X',
     Corda4X: 'CORDA_4X',
+    Ethereum: 'ETHEREUM',
     Fabric2: 'FABRIC_2',
     Sawtooth1X: 'SAWTOOTH_1X'
 } as const;

--- a/packages/cactus-core-api/src/main/go/generated/openapi/go-client/api/openapi.yaml
+++ b/packages/cactus-core-api/src/main/go/generated/openapi/go-client/api/openapi.yaml
@@ -305,6 +305,7 @@ components:
       - BESU_2X
       - BURROW_0X
       - CORDA_4X
+      - ETHEREUM
       - FABRIC_2
       - SAWTOOTH_1X
       type: string

--- a/packages/cactus-core-api/src/main/go/generated/openapi/go-client/model_ledger_type.go
+++ b/packages/cactus-core-api/src/main/go/generated/openapi/go-client/model_ledger_type.go
@@ -24,6 +24,7 @@ const (
 	BESU_2_X LedgerType = "BESU_2X"
 	BURROW_0_X LedgerType = "BURROW_0X"
 	CORDA_4_X LedgerType = "CORDA_4X"
+	ETHEREUM LedgerType = "ETHEREUM"
 	FABRIC_2 LedgerType = "FABRIC_2"
 	SAWTOOTH_1_X LedgerType = "SAWTOOTH_1X"
 )
@@ -34,6 +35,7 @@ var AllowedLedgerTypeEnumValues = []LedgerType{
 	"BESU_2X",
 	"BURROW_0X",
 	"CORDA_4X",
+	"ETHEREUM",
 	"FABRIC_2",
 	"SAWTOOTH_1X",
 }

--- a/packages/cactus-core-api/src/main/json/openapi.json
+++ b/packages/cactus-core-api/src/main/json/openapi.json
@@ -186,6 +186,7 @@
           "BESU_2X",
           "BURROW_0X",
           "CORDA_4X",
+          "ETHEREUM",
           "FABRIC_2",
           "SAWTOOTH_1X"
         ]

--- a/packages/cactus-core-api/src/main/json/openapi.tpl.json
+++ b/packages/cactus-core-api/src/main/json/openapi.tpl.json
@@ -186,6 +186,7 @@
           "BESU_2X",
           "BURROW_0X",
           "CORDA_4X",
+          "ETHEREUM",
           "FABRIC_2",
           "SAWTOOTH_1X"
         ]

--- a/packages/cactus-core-api/src/main/kotlin/generated/openapi/kotlin-client/src/main/kotlin/org/openapitools/client/models/LedgerType.kt
+++ b/packages/cactus-core-api/src/main/kotlin/generated/openapi/kotlin-client/src/main/kotlin/org/openapitools/client/models/LedgerType.kt
@@ -22,7 +22,7 @@ import com.squareup.moshi.JsonClass
 /**
  * Enumerates the different ledger vendors and their major versions encoded within the name of the LedgerType. For example \"BESU_1X\" involves all of the [1.0.0;2.0.0) where 1.0.0 is included and anything up until, but not 2.0.0. See: https://stackoverflow.com/a/4396303/698470 for further explanation.
  *
- * Values: bESU1X,bESU2X,bURROW0X,cORDA4X,fABRIC2,sAWTOOTH1X
+ * Values: bESU1X,bESU2X,bURROW0X,cORDA4X,eTHEREUM,fABRIC2,sAWTOOTH1X
  */
 
 @JsonClass(generateAdapter = false)
@@ -39,6 +39,9 @@ enum class LedgerType(val value: kotlin.String) {
 
     @Json(name = "CORDA_4X")
     cORDA4X("CORDA_4X"),
+
+    @Json(name = "ETHEREUM")
+    eTHEREUM("ETHEREUM"),
 
     @Json(name = "FABRIC_2")
     fABRIC2("FABRIC_2"),

--- a/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-core-api/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -524,6 +524,7 @@ export const LedgerType = {
     Besu2X: 'BESU_2X',
     Burrow0X: 'BURROW_0X',
     Corda4X: 'CORDA_4X',
+    Ethereum: 'ETHEREUM',
     Fabric2: 'FABRIC_2',
     Sawtooth1X: 'SAWTOOTH_1X'
 } as const;


### PR DESCRIPTION
Peter's change: Added the missing ETHEREUM constant to the leger type
that the static consortium plugin has built in to it.
This was necessary because adding it only to the core-api broke the build.
The two types (since they are duplicates of each other) must be updated in
tandem otherwise the code won't compile (which is a good thing because it
is an example if when the compiler saves us from mistakes like this that would
otherwise stay hidden until much later and only come out as runtime errors)

Authored-by: Bruno Mateus

Co-authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Signed-off-by: Rafael Belchior <rafael.belchior@tecnico.ulisboa.pt>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.