### PR TITLE
feat(cactus-connector-ethereum): add RunTransactionV1Exchange to share receipt data

### DIFF
--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/public-api.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/public-api.ts
@@ -3,6 +3,7 @@ export * from "./generated/openapi/typescript-axios";
 export {
   PluginLedgerConnectorEthereum,
   IPluginLedgerConnectorEthereumOptions,
+  RunTransactionV1Exchange,
 } from "./plugin-ledger-connector-ethereum";
 
 export * from "./sign-utils";

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/sign-utils.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/sign-utils.ts
@@ -32,13 +32,16 @@ export function signTransaction(
     | FeeMarketEIP1559Transaction
     | BlobEIP4844Transaction;
 } {
-  let chainConfiguration = new Common({ chain: Chain.Mainnet });
+  let chainConfiguration = new Common({
+    chain: Chain.Mainnet,
+    hardfork: "istanbul",
+  });
   if (customChainInfo) {
     chainConfiguration = Common.custom(customChainInfo);
   }
 
   const transaction = TransactionFactory.fromTxData(txData, {
-    common: chainConfiguration,
+    common: chainConfiguration as any,
   });
   if (privateKey.toLowerCase().startsWith("0x")) {
     privateKey = privateKey.slice(2);

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
@@ -5,7 +5,7 @@
  */
 
 import Web3, { BlockHeaderOutput, FMT_BYTES, FMT_NUMBER } from "web3";
-import { NewHeadsSubscription } from "web3-eth";
+import { NewHeadsSubscription, RegisteredSubscription } from "web3-eth";
 import type { Socket as SocketIoSocket } from "socket.io";
 
 import {
@@ -21,10 +21,7 @@ import {
   WatchBlocksV1,
   Web3Transaction,
 } from "../generated/openapi/typescript-axios";
-import {
-  ConvertWeb3ReturnToString,
-  Web3StringReturnFormat,
-} from "../types/util-types";
+import { ConvertWeb3ReturnToString } from "../types/util-types";
 
 const DEFAULT_HTTP_POLL_INTERVAL = 1000 * 5; // 5 seconds
 const LAST_SEEN_LATEST_BLOCK = -1; // must be negative number, will be replaced with latest block in code
@@ -337,7 +334,7 @@ export class WatchBlocksV1SubscriptionEndpoint extends WatchBlocksV1Endpoint {
   }
 
   public async subscribe() {
-    const { socket, log, web3, isGetBlockData } = this;
+    const { socket, log, isGetBlockData } = this;
     log.info(`${WatchBlocksV1.Subscribe} [WS Subscription] => ${socket.id}`);
 
     if (this.isSubscribed) {
@@ -352,46 +349,53 @@ export class WatchBlocksV1SubscriptionEndpoint extends WatchBlocksV1Endpoint {
     await this.emitAllSinceLastSeenBlock();
 
     log.debug("Subscribing to Web3 new block headers event...");
-    this.newBlocksSubscription = await web3.eth.subscribe(
-      "newBlockHeaders",
-      undefined,
-      Web3StringReturnFormat,
+    const options = {
+      subscription: "newBlockHeaders" as keyof RegisteredSubscription,
+      parameters: {},
+    };
+
+    this.newBlocksSubscription = (await this.web3.eth.subscribe(
+      options.subscription,
+      options.parameters,
+    )) as unknown as NewHeadsSubscription;
+
+    this.newBlocksSubscription?.on(
+      "data",
+      async (blockHeader: BlockHeaderOutput) => {
+        try {
+          log.debug("newBlockHeaders:", blockHeader);
+
+          if (blockHeader.number === undefined || blockHeader.number === null) {
+            throw new Error(
+              `Missing block number in received block header (number: ${blockHeader.number}, hash: ${blockHeader.hash})`,
+            );
+          }
+          const blockNumber = Number(blockHeader.number);
+          if (blockNumber - this.lastSeenBlock > 2) {
+            log.info(
+              `Detected missing blocks since latest one (blockNumber: ${blockNumber}, lastSeenBlock: ${this.lastSeenBlock})`,
+            );
+            await this.emitAllSinceLastSeenBlock();
+          }
+
+          let next: WatchBlocksV1Progress;
+          if (isGetBlockData) {
+            next = await this.getFullBlockProgress(blockNumber);
+          } else {
+            next = await this.headerDataToBlockProgress(blockHeader);
+          }
+
+          socket.emit(WatchBlocksV1.Next, next);
+
+          this.lastSeenBlock = blockNumber;
+        } catch (error) {
+          log.warn("Error when parsing subscribed block data:", error);
+        }
+      },
     );
 
-    this.newBlocksSubscription.on("data", async (blockHeader) => {
-      try {
-        log.debug("newBlockHeaders:", blockHeader);
-
-        if (typeof blockHeader.number === undefined) {
-          throw new Error(
-            `Missing block number in received block header (number: ${blockHeader.number}, hash: ${blockHeader.hash})`,
-          );
-        }
-        const blockNumber = Number(blockHeader.number);
-        if (blockNumber - this.lastSeenBlock > 2) {
-          log.info(
-            `Detected missing blocks since latest one (blockNumber: ${blockNumber}, lastSeenBlock: ${this.lastSeenBlock})`,
-          );
-          await this.emitAllSinceLastSeenBlock();
-        }
-
-        let next: WatchBlocksV1Progress;
-        if (isGetBlockData) {
-          next = await this.getFullBlockProgress(blockNumber);
-        } else {
-          next = await this.headerDataToBlockProgress(blockHeader);
-        }
-
-        socket.emit(WatchBlocksV1.Next, next);
-
-        this.lastSeenBlock = blockNumber;
-      } catch (error) {
-        log.warn("Error when parsing subscribed block data:", error);
-      }
-    });
-
-    this.newBlocksSubscription.on("error", async (error) => {
-      console.log("Error when subscribing to new block header: ", error);
+    this.newBlocksSubscription?.on("error", async (error: Error) => {
+      log.error("Error when subscribing to new block header: ", error);
       socket.emit(WatchBlocksV1.Error, safeStringifyException(error));
       await this.unsubscribe();
     });

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -19,6 +19,7 @@ import { v4 as uuidV4 } from "uuid";
 import { AddressInfo } from "net";
 import { Server as SocketIoServer } from "socket.io";
 import Web3, { HexString } from "web3";
+import { Address } from "@ethereumjs/util";
 
 import {
   LogLevelDesc,
@@ -351,11 +352,11 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
 
   test("invoke Web3SigningCredentialType.None", async () => {
     const testEthAccount2 = web3.eth.accounts.create();
-
+    const address = Address.fromString(testEthAccount2.address);
     const value = 10e6;
     const { serializedTransactionHex } = signTransaction(
       {
-        to: testEthAccount2.address,
+        to: address,
         value,
         maxPriorityFeePerGas: 0,
         maxFeePerGas: 0x40000000,


### PR DESCRIPTION
Also improves watch blocks

Authored-by: Bruno Mateus <brumat315@gmail.com>
Co-authored-by: Rafael Belchior <rafael.belchior@tecnico.ulisboa.pt>
Signed-off-by: Rafael Belchior <rafael.belchior@tecnico.ulisboa.pt>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.