### PR TITLE
ci(github): fix type exports in packages/cactus-common

### DIFF
--- a/packages/cactus-common/src/main/typescript/log-level.ts
+++ b/packages/cactus-common/src/main/typescript/log-level.ts
@@ -1,0 +1,18 @@
+export const LogLevel = {
+  TRACE: 0,
+  DEBUG: 1,
+  INFO: 2,
+  WARN: 3,
+  ERROR: 4,
+  SILENT: 5,
+} as const;
+export type LogLevelNumbers = (typeof LogLevel)[keyof typeof LogLevel];
+export type LogLevelDesc =
+  | LogLevelNumbers
+  | "trace"
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "silent"
+  | keyof typeof LogLevel;

--- a/packages/cactus-common/src/main/typescript/public-api.ts
+++ b/packages/cactus-common/src/main/typescript/public-api.ts
@@ -1,6 +1,7 @@
 export { LoggerProvider } from "./logging/logger-provider";
 export { Logger, ILoggerOptions } from "./logging/logger";
-export { LogLevelDesc } from "loglevel";
+export { LogLevel, LogLevelNumbers, LogLevelDesc } from "./log-level";
+
 export { Objects } from "./objects";
 export { Strings } from "./strings";
 export { Bools } from "./bools";

--- a/tools/custom-checks/get-all-tgz-path.ts
+++ b/tools/custom-checks/get-all-tgz-path.ts
@@ -58,8 +58,6 @@ export async function getAllTgzPath(): Promise<IGetAllTgzPathResponse> {
       "packages/cactus-verifier-client/hyperledger-cactus-verifier-client-*.tgz",
       // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3634
       "packages/cactus-plugin-ledger-connector-polkadot/hyperledger-cactus-plugin-ledger-connector-polkadot-*.tgz",
-      // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3635
-      "packages/cactus-common/hyperledger-cactus-common-*.tgz",
     ],
   };
 


### PR DESCRIPTION
### Commit to be reviewed
---
ci(github): fix type exports in packages/cactus-common
```
Primary Changes
---------------
1. Removed packages/cactus-common/hyperledger-cactus-common-*.tgz in ignore 
paths in get-all-tgz-path.ts file
2. Added the log-level.ts for the missing exports detected by attw -f json
3. Added exports in public-api.ts from log-level.ts
```

Fixes: #3635

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.