### PR TITLE
ci(github): fix type exports in packages/cactus-verifier-client

### DIFF
--- a/packages/cactus-verifier-client/src/main/typescript/public-api.ts
+++ b/packages/cactus-verifier-client/src/main/typescript/public-api.ts
@@ -1,4 +1,4 @@
-export { Verifier, IVerifierEventListener, LedgerEvent } from "./verifier";
+export { Verifier } from "./verifier";
 export { getValidatorApiClient } from "./get-validator-api-client";
 export {
   VerifierFactory,

--- a/packages/cactus-verifier-client/src/main/typescript/verifier.ts
+++ b/packages/cactus-verifier-client/src/main/typescript/verifier.ts
@@ -18,11 +18,6 @@ import {
   IVerifierEventListener,
 } from "@hyperledger/cactus-core-api";
 
-export {
-  IVerifierEventListener,
-  LedgerEvent,
-} from "@hyperledger/cactus-core-api";
-
 /**
  * Utility type for retrieving monitoring event / new block type from generic ISocketApiClient interface.
  */

--- a/packages/cactus-verifier-client/src/test/typescript/unit/verifier.test.ts
+++ b/packages/cactus-verifier-client/src/test/typescript/unit/verifier.test.ts
@@ -18,12 +18,12 @@ const log: Logger = LoggerProvider.getOrCreate({
   level: testLogLevel,
 });
 
-import { ISocketApiClient } from "@hyperledger/cactus-core-api";
 import {
-  Verifier,
+  ISocketApiClient,
   IVerifierEventListener,
   LedgerEvent,
-} from "../../../main/typescript/verifier";
+} from "@hyperledger/cactus-core-api";
+import { Verifier } from "../../../main/typescript/verifier";
 
 //////////////////////////////////
 // Test Timeout

--- a/tools/custom-checks/get-all-tgz-path.ts
+++ b/tools/custom-checks/get-all-tgz-path.ts
@@ -54,8 +54,6 @@ export async function getAllTgzPath(): Promise<IGetAllTgzPathResponse> {
       "examples/cactus-example-cbdc-bridging-frontend/hyperledger-cacti-example-cbdc-bridging-frontend-*.tgz",
       // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3632
       "examples/cactus-common-example-server/hyperledger-cactus-common-example-server-*.tgz",
-      // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3633
-      "packages/cactus-verifier-client/hyperledger-cactus-verifier-client-*.tgz",
       // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3634
       "packages/cactus-plugin-ledger-connector-polkadot/hyperledger-cactus-plugin-ledger-connector-polkadot-*.tgz",
       // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3635


### PR DESCRIPTION
### Commit to be reviewed
---
ci(github): fix type exports in packages/cactus-verifier-client
```
Primary Changes
---------------
1. Removed packages/cactus-verifier-client/hyperledger-cactus-verifier-
client-*.tgz in ignore paths in get-all-tgz-path.ts file
2. Removed the export of IVerifierEventListener and LedgerEvent from
./verifier and changed it to source from @hyperledger/cactus-core-api to
resolve the type export issue encountered in this package
```

Fixes: #3633

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.