### PR TITLE
docs(readme): fix container image build cmds: drop / from branch names

### DIFF
--- a/examples/cactus-example-supply-chain-backend/README.md
+++ b/examples/cactus-example-supply-chain-backend/README.md
@@ -32,7 +32,7 @@ DOCKER_BUILDKIT=1 docker build --file \
   ./examples/cactus-example-supply-chain-backend/Dockerfile \
   . \
   --tag scaeb \
-  --tag ghcr.io/hyperledger/cactus-example-supply-chain-app:$(git describe --contains --all HEAD)_$(git rev-parse --short HEAD)_$(date -u +"%Y-%m-%dT%H-%M-%SZ")
+  --tag ghcr.io/hyperledger/cactus-example-supply-chain-app:$(git describe --contains --all HEAD | sed -r 's,/,-,g')_$(git rev-parse --short HEAD)_$(date -u +"%Y-%m-%dT%H-%M-%SZ")
 
 # Run the built image with ports mapped to the host machine as you see fit
 # The --privileged flag is required because we use Docker-in-Docker for pulling


### PR DESCRIPTION
Previously if you executed the image build commands that use the branch name
to produce container image tag names then you received an error if your branch
name contained a forward slash (/) which is common for people who use VSCode
extensions for managing branches related to pull requests.

The new commands are using `sed` to remove the forward slashes from the branch names
and replace them with underscores (_) so that the container image tags are
valid.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.