### PR TITLE
ci(trivy): fix scan failures due to TOOMANYREQUESTS DB error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -499,7 +499,7 @@ jobs:
             --tag cmd-api-server \
             --tag "ghcr.io/hyperledger/cactus-cmd-api-server:$(date +"%Y-%m-%dT%H-%M-%S" --utc)-dev-$(git rev-parse --short HEAD)"
 
-      - if: ${{ env.RUN_TRIVY_SCAN == 'true' }}
+      - if: ${{ env.RUN_TRIVY_SCAN == 'true' && github.event.name == 'schedule' }}
         name: Run Trivy vulnerability scan for cmd-api-server
         uses: aquasecurity/trivy-action@0.19.0
         with:
@@ -1423,7 +1423,7 @@ jobs:
         working-directory: packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/
         run: ./gradlew clean build -Pversion=dev -DrootProjectName=cacti-connector-corda-server
   
-      - if: ${{ env.RUN_TRIVY_SCAN == 'true' }}
+      - if: ${{ env.RUN_TRIVY_SCAN == 'true' && github.event.name == 'schedule' }}
         name: Run Trivy vulnerability scan for cactus-connector-corda-server
         uses: aquasecurity/trivy-action@0.19.0
         with:
@@ -2283,7 +2283,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - name: ghcr.io/hyperledger/cactus-keychain-vault-server
         run: DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-keychain-vault/src/cactus-keychain-vault-server/ -f ./packages/cactus-plugin-keychain-vault/src/cactus-keychain-vault-server/Dockerfile -t cactus-keychain-vault-server
-      - if: ${{ env.RUN_TRIVY_SCAN == 'true' }}
+      - if: ${{ env.RUN_TRIVY_SCAN == 'true' && github.event.name == 'schedule' }}
         name: Run Trivy vulnerability scan for cactus-keychain-vault-server
         uses: aquasecurity/trivy-action@0.19.0
         with:
@@ -2305,3 +2305,6 @@ name: Cactus_CI
     branches:
       - main
       - dev
+  schedule:
+    # Run at 8:00 AM UTC on weekends (Monday and Thursday)
+    - cron: "0 8 * * 1,4" 


### PR DESCRIPTION
## Commit to be reviewed
---
ci(trivy): fix scan failures due to TOOMANYREQUESTS DB error
```
Primary Changes
----------------
1. Updated the ci.yaml to make the trivy scan 
   run only on the weekends
```
Fixes #3652

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.