### PR TITLE
feat: add proto-definitions and update table structure

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/knex/migrations/20220331132128_create_logs_table.ts
+++ b/packages/cactus-plugin-satp-hermes/src/knex/migrations/20220331132128_create_logs_table.ts
@@ -8,6 +8,7 @@ export function up(knex: Knex): Knex.SchemaBuilder {
     table.string("operation").notNullable();
     table.string("timestamp").notNullable();
     table.string("data").notNullable();
+    table.bigInteger("sequenceNumber").notNullable();
   });
 }
 

--- a/packages/cactus-plugin-satp-hermes/src/main/proto/cacti/satp/v02/crash_recovery.proto
+++ b/packages/cactus-plugin-satp-hermes/src/main/proto/cacti/satp/v02/crash_recovery.proto
@@ -4,10 +4,86 @@ package cacti.satp.v02.crash;
 
 import "google/protobuf/empty.proto";
 
-// TODO: Rollback and crash-recovery related
 service CrashRecovery   {
   // util RPCs
 
   // step RPCs
+  rpc RecoverV2Message(RecoverMessage) returns (RecoverUpdateMessage);
+  rpc RecoverV2SuccessMessage(RecoverSuccessMessage) returns (google.protobuf.Empty);
+  rpc RollbackV2Message(RollbackMessage) returns (RollbackAckMessage);
+}
 
+message RecoverMessage {
+  string session_id = 1;
+  string message_type = 2;
+  string satp_phase = 3;
+  int32 sequence_number = 4;
+  bool is_backup = 5;
+  string new_identity_public_key = 6;
+  int64 last_entry_timestamp = 7;
+  string sender_signature = 8;
+}
+
+message RecoverUpdateMessage {
+  string session_id = 1;
+  string message_type = 2;
+  string hash_recover_message = 3;
+  repeated LocalLog recovered_logs = 4;
+  string sender_signature = 5;
+}
+
+message RecoverSuccessMessage {
+  string session_id = 1;
+  string message_type = 2;
+  string hash_recover_update_message = 3;
+  bool success = 4;
+  repeated string entries_changed = 5;
+  string sender_signature = 6;
+}
+
+message RollbackMessage {
+  string session_id = 1;
+  string message_type = 2;
+  bool success = 3;
+  repeated string actions_performed = 4;
+  repeated string proofs = 5;
+  string sender_signature = 6;
+}
+
+message RollbackAckMessage {
+  string session_id = 1;
+  string message_type = 2;
+  bool success = 3;
+  repeated string actions_performed = 4;
+  repeated string proofs = 5;
+  string sender_signature = 6;
+}
+
+message LocalLog {
+  string session_id = 1;
+  string type = 2;
+  string key = 3;
+  string operation = 4;
+  string timestamp = 5;
+  string data = 6;
+  int32 sequence_number = 7;
+}
+
+message RollbackLogEntry {
+  string session_id = 1;
+  string stage = 2;
+  string timestamp = 3;
+  string action = 4; // action performed during rollback
+  string status = 5; // status of rollback (e.g., SUCCESS, FAILED)
+  string details = 6; // Additional details or metadata about the rollback
+}
+
+message RollbackState {
+  string session_id = 1;
+  string current_stage = 2;
+  int32 steps_remaining = 3;
+  repeated RollbackLogEntry rollback_log_entries = 4;
+  string estimated_time_to_completion = 5;
+  string status = 6; // Overall status (e.g., IN_PROGRESS, COMPLETED, FAILED)
+  string details = 7; // Additional metadata or information
 }

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/repository/interfaces/repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/repository/interfaces/repository.ts
@@ -15,6 +15,10 @@ export interface ILocalLogRepository extends IRepository<LocalLog, string> {
   readLastestLog(sessionID: string): Promise<LocalLog>;
   create(log: LocalLog): Promise<LocalLog>;
   deleteBySessionId(log: string): any;
+  fetchLogsFromSequence(
+    sessionId: string,
+    sequenceNumber: number,
+  ): Promise<LocalLog[]>;
   destroy(): any;
   reset(): any;
 }

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/repository/knex-local-log-repository.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/repository/knex-local-log-repository.ts
@@ -54,6 +54,15 @@ export class KnexLocalLogRepository implements ILocalLogRepository {
       .groupBy("sessionID");
   }
 
+  fetchLogsFromSequence(
+    sessionId: string,
+    sequenceNumber: number,
+  ): Promise<LocalLog[]> {
+    return this.getLogsTable()
+      .where("sessionID", sessionId)
+      .andWhere("sequenceNumber", ">", sequenceNumber);
+  }
+
   async reset() {
     await this.database.migrate.rollback();
     await this.database.migrate.latest();


### PR DESCRIPTION
## Description
- Added new protocol buffer definitions to extend functionality for Crash Recovery RPCs.
- Modified the database table structure to include the sequence_number field from `sessionData`. This enhancement enables retrieving logs from the server that has a sequence number greater than the one provided by the client, improving synchronization during rollback and recovery processes.

Addresses #3114 

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.