### PR TITLE
fix(security): upgrade http-proxy-middleware to >=2.0.7 to mitigate DoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
     "glob-parent": ">=5.1.2",
     "x-hoek": ">6.1.3",
     "http-cache-semantics": ">=4.1.1",
+    "http-proxy-middleware@2.0.6": "2.0.7",
+    "http-proxy-middleware@^2.0.3": "2.0.7",
     "x-ip": ">2.0.1",
     "jsonwebtoken": ">=9.0.0",
     "jsrsasign": ">=11.0.0",

--- a/packages/cactus-plugin-ledger-connector-ethereum/package.json
+++ b/packages/cactus-plugin-ledger-connector-ethereum/package.json
@@ -74,7 +74,7 @@
     "axios": "1.7.7",
     "ethers": "6.8.1",
     "express": "4.21.0",
-    "http-proxy-middleware": "2.0.6",
+    "http-proxy-middleware": "2.0.7",
     "minimist": "1.2.8",
     "prom-client": "15.1.3",
     "run-time-error-cjs": "1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10510,7 +10510,7 @@ __metadata:
     chalk: "npm:4.1.2"
     ethers: "npm:6.8.1"
     express: "npm:4.21.0"
-    http-proxy-middleware: "npm:2.0.6"
+    http-proxy-middleware: "npm:2.0.7"
     js-yaml: "npm:4.1.0"
     minimist: "npm:1.2.8"
     prom-client: "npm:15.1.3"
@@ -17167,11 +17167,11 @@ __metadata:
   linkType: hard
 
 "@types/http-proxy@npm:^1.17.8":
-  version: 1.17.9
-  resolution: "@types/http-proxy@npm:1.17.9"
+  version: 1.17.15
+  resolution: "@types/http-proxy@npm:1.17.15"
   dependencies:
     "@types/node": "npm:*"
-  checksum: 10/48075c535a5d4805feca388a539b4dcb80666963499018918584aefb4f7806c2c86b0c289bb0f1d96539816d90d702b7c2167e68c3ebe858725e598a1c3c05d2
+  checksum: 10/fa86d5397c021f6c824d1143a206009bfb64ff703da32fb30f6176c603daf6c24ce3a28daf26b3945c94dd10f9d76f07ea7a6a2c3e9b710e00ff42da32e08dea
   languageName: node
   linkType: hard
 
@@ -32792,9 +32792,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:2.0.6, http-proxy-middleware@npm:^2.0.3":
-  version: 2.0.6
-  resolution: "http-proxy-middleware@npm:2.0.6"
+"http-proxy-middleware@npm:2.0.7":
+  version: 2.0.7
+  resolution: "http-proxy-middleware@npm:2.0.7"
   dependencies:
     "@types/http-proxy": "npm:^1.17.8"
     http-proxy: "npm:^1.18.1"
@@ -32806,7 +32806,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/express":
       optional: true
-  checksum: 10/768e7ae5a422bbf4b866b64105b4c2d1f468916b7b0e9c96750551c7732383069b411aa7753eb7b34eab113e4f77fb770122cb7fb9c8ec87d138d5ddaafda891
+  checksum: 10/4a51bf612b752ad945701995c1c029e9501c97e7224c0cf3f8bf6d48d172d6a8f2b57c20fec469534fdcac3aa8a6f332224a33c6b0d7f387aa2cfff9b67216fd
   languageName: node
   linkType: hard
 
@@ -39348,7 +39348,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.5":
+"micromatch@npm:^4.0.2":
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
+  dependencies:
+    braces: "npm:^3.0.3"
+    picomatch: "npm:^2.3.1"
+  checksum: 10/6bf2a01672e7965eb9941d1f02044fad2bd12486b5553dc1116ff24c09a8723157601dc992e74c911d896175918448762df3b3fd0a6b61037dd1a9766ddfbf58
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:


### PR DESCRIPTION
Versions of the package http-proxy-middleware before 2.0.7, from 3.0.0 and
 before 3.0.3 are vulnerable to Denial of Service (DoS) due to an UnhandledPromiseRejection
 error thrown by micromatch. An attacker could kill the Node.js process
 and crash the server by making requests to certain paths.

CVE ID
CVE-2024-21536

GHSA ID
GHSA-c7qv-q95q-8v27

https://github.com/hyperledger-cacti/cacti/security/dependabot/1323

Fixes #3661

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.