### PR TITLE
feat: add satp logging in all satges

### DIFF
--- a/packages/cactus-plugin-satp-hermes/package.json
+++ b/packages/cactus-plugin-satp-hermes/package.json
@@ -89,7 +89,7 @@
     "db:migrate": "knex migrate:latest --knexfile src/knex/knexfile.js",
     "db:migrate:production": "knex migrate:latest --env production --knexfile src/knex/knexfile.ts",
     "db:seed": "knex seed:run --knexfile src/knex/knexfile.ts",
-    "db:cleanup": "find src/knex/data -name '.dev-*.sqlite3' -delete"
+    "db:cleanup": "find src/knex/ -name '.dev.local-*.sqlite3' -delete"
   },
   "jest": {
     "moduleNameMapper": {
@@ -137,6 +137,7 @@
     "kubo-rpc-client": "3.0.1",
     "npm-run-all": "4.1.5",
     "openzeppelin-solidity": "3.4.2",
+    "pg": "8.13.1",
     "safe-stable-stringify": "2.5.0",
     "secp256k1": "4.0.3",
     "socket.io": "4.6.2",
@@ -160,6 +161,7 @@
     "@types/fs-extra": "11.0.4",
     "@types/google-protobuf": "3.15.12",
     "@types/node": "18.18.2",
+    "@types/pg": "8.11.10",
     "@types/swagger-ui-express": "4.1.6",
     "@types/tape": "4.13.4",
     "@types/uuid": "10.0.0",

--- a/packages/cactus-plugin-satp-hermes/src/knex/knexfile-remote.ts
+++ b/packages/cactus-plugin-satp-hermes/src/knex/knexfile-remote.ts
@@ -1,11 +1,12 @@
 import path from "path";
 import { v4 as uuidv4 } from "uuid";
 import dotenv from "dotenv";
+import { Knex } from "knex";
 
 const envPath = process.env.ENV_PATH;
 dotenv.config({ path: envPath });
 
-module.exports = {
+const config: { [key: string]: Knex.Config } = {
   development: {
     client: "sqlite3",
     connection: {
@@ -20,7 +21,7 @@ module.exports = {
     client: "pg",
     connection: {
       host: process.env.DB_HOST,
-      port: process.env.DB_PORT,
+      port: Number(process.env.DB_PORT),
       user: process.env.DB_USER,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
@@ -30,3 +31,5 @@ module.exports = {
     },
   },
 };
+
+export default config;

--- a/packages/cactus-plugin-satp-hermes/src/knex/knexfile.ts
+++ b/packages/cactus-plugin-satp-hermes/src/knex/knexfile.ts
@@ -1,15 +1,16 @@
 import path from "path";
 import { v4 as uuidv4 } from "uuid";
 import dotenv from "dotenv";
+import { Knex } from "knex";
 
 const envPath = process.env.ENV_PATH;
 dotenv.config({ path: envPath });
 
-module.exports = {
+const config: { [key: string]: Knex.Config } = {
   development: {
     client: "sqlite3",
     connection: {
-      filename: path.join(__dirname, "data", "/.dev-" + uuidv4() + ".sqlite3"),
+      filename: path.resolve(__dirname, `.dev.local-${uuidv4()}.sqlite3`),
     },
     migrations: {
       directory: path.resolve(__dirname, "migrations"),
@@ -23,7 +24,7 @@ module.exports = {
     client: "pg",
     connection: {
       host: process.env.DB_HOST,
-      port: process.env.DB_PORT,
+      port: Number(process.env.DB_PORT),
       user: process.env.DB_USER,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
@@ -33,3 +34,5 @@ module.exports = {
     },
   },
 };
+
+export default config;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/dispatcher.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/dispatcher.ts
@@ -32,6 +32,10 @@ import { IntegrationsEndpointV1 } from "../web-services/integrations-endpoint";
 import { executeGetHealthCheck } from "./admin/get-healthcheck-handler-service";
 import { executeGetStatus } from "./admin/get-status-handler-service";
 import { executeTransact } from "./transaction/transact-handler-service";
+import {
+  ILocalLogRepository,
+  IRemoteLogRepository,
+} from "../repository/interfaces/repository";
 
 export interface BLODispatcherOptions {
   logger: Logger;
@@ -41,6 +45,8 @@ export interface BLODispatcherOptions {
   signer: JsObjectSigner;
   bridgesManager: SATPBridgesManager;
   pubKey: string;
+  localRepository: ILocalLogRepository;
+  remoteRepository: IRemoteLogRepository;
 }
 
 export class BLODispatcher {
@@ -54,6 +60,8 @@ export class BLODispatcher {
   private manager: SATPManager;
   private orchestrator: GatewayOrchestrator;
   private bridgeManager: SATPBridgesManager;
+  private localRepository: ILocalLogRepository;
+  private remoteRepository: IRemoteLogRepository;
 
   constructor(public readonly options: BLODispatcherOptions) {
     const fnTag = `${BLODispatcher.CLASS_NAME}#constructor()`;
@@ -61,12 +69,17 @@ export class BLODispatcher {
 
     this.level = this.options.logLevel || "INFO";
     this.label = this.className;
-    this.logger = LoggerProvider.getOrCreate({ level: this.level, label: this.label });
+    this.logger = LoggerProvider.getOrCreate({
+      level: this.level,
+      label: this.label,
+    });
     this.instanceId = options.instanceId;
     this.logger.info(`Instantiated ${this.className} OK`);
     this.orchestrator = options.orchestrator;
     const signer = options.signer;
     const ourGateway = this.orchestrator.ourGateway;
+    this.localRepository = options.localRepository;
+    this.remoteRepository = options.remoteRepository;
 
     this.bridgeManager = options.bridgesManager;
 
@@ -78,6 +91,8 @@ export class BLODispatcher {
       bridgeManager: this.bridgeManager,
       orchestrator: this.orchestrator,
       pubKey: options.pubKey,
+      localRepository: this.localRepository,
+      remoteRepository: this.remoteRepository,
     };
 
     this.manager = new SATPManager(SATPManagerOpts);

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/satp-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/satp-service.ts
@@ -9,6 +9,7 @@ import { SatpStage0Service } from "../../generated/proto/cacti/satp/v02/stage_0_
 import { SatpStage1Service } from "../../generated/proto/cacti/satp/v02/stage_1_pb";
 import { SatpStage2Service } from "../../generated/proto/cacti/satp/v02/stage_2_pb";
 import { SatpStage3Service } from "../../generated/proto/cacti/satp/v02/stage_3_pb";
+import { SATPLogger } from "../../logging";
 
 export enum SATPServiceType {
   Server = "Server",
@@ -24,6 +25,7 @@ export type ISATPServiceOptions = {
   signer: JsObjectSigner;
   serviceType: SATPServiceType;
   bridgeManager?: SATPBridgesManager;
+  dbLogger: SATPLogger;
 };
 
 export interface SATPServiceStatic {
@@ -56,6 +58,7 @@ export abstract class SATPService {
   readonly serviceType: SATPServiceType;
   private readonly signer: JsObjectSigner;
   readonly serviceName: string;
+  public dbLogger: SATPLogger;
 
   constructor(ops: ISATPServiceOptions) {
     this.logger = LoggerProvider.getOrCreate(ops.loggerOptions);
@@ -63,6 +66,10 @@ export abstract class SATPService {
     this.serviceType = ops.serviceType;
     this.stage = ops.stage;
     this.signer = ops.signer;
+    if (!ops.dbLogger) {
+      throw new Error("dbLogger is required for SATPService");
+    }
+    this.dbLogger = ops.dbLogger;
     this.logger.trace(`Signer logger level: ${this.signer.options.logLevel}`);
   }
 

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/types.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/types.ts
@@ -12,6 +12,7 @@ import { IMergePolicyValue } from "@hyperledger/cactus-plugin-bungee-hermes/dist
 import { NetworkBridge } from "./stage-services/satp-bridge/network-bridge";
 import { SATPServiceInstance } from "./stage-services/satp-service";
 import { NetworkConfig } from "../types/blockchain-interaction";
+import { Knex } from "knex";
 
 export type SATPConnectHandler = (
   gateway: SATPGateway,
@@ -81,6 +82,8 @@ export interface SATPGatewayConfig {
   privacyPolicies?: IPrivacyPolicyValue[];
   mergePolicies?: IMergePolicyValue[];
   bridgesConfig?: NetworkConfig[];
+  knexLocalConfig?: Knex.Config;
+  knexRemoteConfig?: Knex.Config;
 }
 
 // export interface SATPBridgeConfig {
@@ -106,10 +109,11 @@ export function isOfType<T>(
 export interface LocalLog {
   sessionID: string;
   type: string;
-  key?: string;
+  key: string;
   operation: string;
   timestamp?: string;
   data: string;
+  sequenceNumber: number;
 }
 export interface RemoteLog {
   key: string;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/logging.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/logging.ts
@@ -1,0 +1,173 @@
+import { LocalLog, RemoteLog } from "./core/types";
+import {
+  ILocalLogRepository,
+  IRemoteLogRepository,
+} from "./repository/interfaces/repository";
+import {
+  JsObjectSigner,
+  Logger,
+  LoggerProvider,
+  LogLevelDesc,
+} from "@hyperledger/cactus-common";
+import { SHA256 } from "crypto-js";
+import { stringify as safeStableStringify } from "safe-stable-stringify";
+import { bufArray2HexStr, getSatpLogKey, sign } from "./gateway-utils";
+
+interface SATPLogEntry {
+  sessionID: string;
+  type: string;
+  operation: string;
+  data: string;
+  sequenceNumber: number;
+}
+
+export interface ISATPLoggerConfig {
+  localRepository: ILocalLogRepository;
+  remoteRepository: IRemoteLogRepository;
+  signer: JsObjectSigner;
+  pubKey: string;
+}
+
+export class SATPLogger {
+  public localRepository: ILocalLogRepository;
+  public remoteRepository: IRemoteLogRepository;
+  private signer: JsObjectSigner;
+  private pubKey: string;
+  private readonly log: Logger;
+
+  constructor(config: ISATPLoggerConfig) {
+    this.localRepository = config.localRepository;
+    this.remoteRepository = config.remoteRepository;
+    this.signer = config.signer;
+    this.pubKey = config.pubKey;
+
+    const logLevel: LogLevelDesc = "INFO";
+    this.log = LoggerProvider.getOrCreate({
+      label: "SATPLogger",
+      level: logLevel,
+    });
+
+    this.log.info("SATPLogger initialized.");
+  }
+
+  public async storeProof(logEntry: SATPLogEntry): Promise<void> {
+    const fnTag = `SATPLogger#storeProof()`;
+    this.log.info(
+      `${fnTag} - Storing proof log entry for sessionID: ${logEntry.sessionID}`,
+    );
+
+    if (logEntry.data == undefined) {
+      this.log.warn(`${fnTag} - No data provided in log entry.`);
+      return;
+    }
+
+    const key = getSatpLogKey(
+      logEntry.sessionID,
+      logEntry.type,
+      logEntry.operation,
+    );
+    const localLog: LocalLog = {
+      sessionID: logEntry.sessionID,
+      type: logEntry.type,
+      key: key,
+      timestamp: Date.now().toString(),
+      operation: logEntry.operation,
+      data: logEntry.data,
+      sequenceNumber: logEntry.sequenceNumber,
+    };
+
+    await this.storeInDatabase(localLog);
+
+    const hash = SHA256(localLog.data).toString();
+
+    this.log.debug(`${fnTag} - generated hash: ${hash}`);
+    await this.storeRemoteLog(localLog.key, hash);
+  }
+
+  public async persistLogEntry(logEntry: SATPLogEntry): Promise<void> {
+    const fnTag = `SATPLogger#persistLogEntry()`;
+    this.log.info(
+      `${fnTag} - Persisting log entry for sessionID: ${logEntry.sessionID}`,
+    );
+
+    const key = getSatpLogKey(
+      logEntry.sessionID,
+      logEntry.type,
+      logEntry.operation,
+    );
+    const localLog: LocalLog = {
+      sessionID: logEntry.sessionID,
+      type: logEntry.type,
+      key: key,
+      timestamp: Date.now().toString(),
+      operation: logEntry.operation,
+      data: logEntry.data,
+      sequenceNumber: logEntry.sequenceNumber,
+    };
+
+    await this.storeInDatabase(localLog);
+
+    const hash = this.getHash(localLog);
+
+    this.log.debug(`${fnTag} - generated hash: ${hash}`);
+    await this.storeRemoteLog(localLog.key, hash);
+  }
+
+  private getHash(logEntry: LocalLog): string {
+    const fnTag = `SATPLogger#getHash()`;
+    this.log.debug(
+      `${fnTag} - generating hash for log entry with sessionID: ${logEntry.sessionID}`,
+    );
+
+    return SHA256(
+      safeStableStringify(logEntry, [
+        "sessionID",
+        "type",
+        "key",
+        "operation",
+        "timestamp",
+        "data",
+        "sequenceNumber",
+      ]),
+    ).toString();
+  }
+
+  private async storeInDatabase(localLog: LocalLog): Promise<void> {
+    const fnTag = `SATPLogger#storeInDatabase()`;
+    this.log.info(`${fnTag} - Storing log entry with key: ${localLog.key}`);
+
+    await this.localRepository.create(localLog);
+  }
+
+  private async storeRemoteLog(key: string, hash: string): Promise<void> {
+    const fnTag = `SATPLogger#storeRemoteLog()`;
+    this.log.info(
+      `${fnTag} - Storing remote log with key: ${key} and hash: ${hash}`,
+    );
+
+    const remoteLog: RemoteLog = {
+      key: key,
+      hash: hash,
+      signature: "",
+      signerPubKey: this.pubKey,
+    };
+
+    remoteLog.signature = bufArray2HexStr(
+      sign(this.signer, safeStableStringify(remoteLog)),
+    );
+
+    this.log.debug(`${fnTag} - Generated signature: ${remoteLog.signature}`);
+    const response = await this.remoteRepository.create(remoteLog);
+
+    if (response.status < 200 || response.status > 299) {
+      this.log.error(
+        `${fnTag} - Failed to store remote log. Response status: ${response.status}`,
+      );
+      throw new Error(
+        `${fnTag} - Got response ${response.status} when logging to remote`,
+      );
+    }
+
+    this.log.info(`${fnTag} - Successfully stored remote log.`);
+  }
+}

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
@@ -43,6 +43,8 @@ import {
   ILocalLogRepository,
   IRemoteLogRepository,
 } from "./repository/interfaces/repository";
+import { KnexRemoteLogRepository as RemoteLogRepository } from "./repository/knex-remote-log-repository";
+import { KnexLocalLogRepository as LocalLogRepository } from "./repository/knex-local-log-repository";
 import { BLODispatcher, BLODispatcherOptions } from "./blo/dispatcher";
 import swaggerUi, { JsonObject } from "swagger-ui-express";
 import {
@@ -109,6 +111,9 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
     this.logger = LoggerProvider.getOrCreate(logOptions);
     this.logger.info("Initializing Gateway Coordinator");
 
+    this.localRepository = new LocalLogRepository(options.knexLocalConfig);
+    this.remoteRepository = new RemoteLogRepository(options.knexRemoteConfig);
+
     if (this.config.keyPair == undefined) {
       throw new Error("Key pair is undefined");
     }
@@ -162,6 +167,8 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
       signer: this.signer,
       bridgesManager: this.bridgesManager,
       pubKey: this.pubKey,
+      localRepository: this.localRepository,
+      remoteRepository: this.remoteRepository,
     };
 
     this.supportedDltIDs = this.config.gid!.supportedDLTs;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9279,6 +9279,7 @@ __metadata:
     "@types/fs-extra": "npm:11.0.4"
     "@types/google-protobuf": "npm:3.15.12"
     "@types/node": "npm:18.18.2"
+    "@types/pg": "npm:8.11.10"
     "@types/swagger-ui-express": "npm:4.1.6"
     "@types/tape": "npm:4.13.4"
     "@types/uuid": "npm:10.0.0"
@@ -9308,6 +9309,7 @@ __metadata:
     make-dir-cli: "npm:3.1.0"
     npm-run-all: "npm:4.1.5"
     openzeppelin-solidity: "npm:3.4.2"
+    pg: "npm:8.13.1"
     protobufjs: "npm:7.2.5"
     safe-stable-stringify: "npm:2.5.0"
     secp256k1: "npm:4.0.3"
@@ -16279,6 +16281,17 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/bebe1e596cbbe5f7d2726a58859e61986c5a42459048e29cb7f2d4d764be6bbb0844572fd5d70ca8955a8a17e8b4ed80984fc4903e165d9efb8807a3fbb051aa
+  languageName: node
+  linkType: hard
+
+"@types/pg@npm:8.11.10":
+  version: 8.11.10
+  resolution: "@types/pg@npm:8.11.10"
+  dependencies:
+    "@types/node": "npm:*"
+    pg-protocol: "npm:*"
+    pg-types: "npm:^4.0.1"
+  checksum: 10/65b7d7ca9c90b7cb94aa94ad94bb1883356845e1f64688bc824ecd499da25f63a2400f0a58500554637048a7cc8b91055bbfe14301c082ce9669afd0c18e414c
   languageName: node
   linkType: hard
 
@@ -39546,7 +39559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"obuf@npm:^1.0.0, obuf@npm:^1.1.2":
+"obuf@npm:^1.0.0, obuf@npm:^1.1.2, obuf@npm:~1.1.2":
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
   checksum: 10/53ff4ab3a13cc33ba6c856cf281f2965c0aec9720967af450e8fd06cfd50aceeefc791986a16bcefa14e7898b3ca9acdfcf15b9d9a1b9c7e1366581a8ad6e65e
@@ -40809,6 +40822,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-cloudflare@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pg-cloudflare@npm:1.1.1"
+  checksum: 10/45ca0c7926967ec9e66a9efc73ca57e3e933671b541bc774631a02ce683e7f658d0a4e881119b3f61486f38e344ae1b008d3a20eb5e21701c5fa8ff8382c5538
+  languageName: node
+  linkType: hard
+
 "pg-connection-string@npm:2.5.0":
   version: 2.5.0
   resolution: "pg-connection-string@npm:2.5.0"
@@ -40823,7 +40843,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-connection-string@npm:^2.5.0":
+"pg-connection-string@npm:^2.5.0, pg-connection-string@npm:^2.7.0":
   version: 2.7.0
   resolution: "pg-connection-string@npm:2.7.0"
   checksum: 10/68015a8874b7ca5dad456445e4114af3d2602bac2fdb8069315ecad0ff9660ec93259b9af7186606529ac4f6f72a06831e6f20897a689b16cc7fda7ca0e247fd
@@ -40837,7 +40857,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-pool@npm:^3.5.2":
+"pg-numeric@npm:1.0.2":
+  version: 1.0.2
+  resolution: "pg-numeric@npm:1.0.2"
+  checksum: 10/8899f8200caa1744439a8778a9eb3ceefb599d893e40a09eef84ee0d4c151319fd416634a6c0fc7b7db4ac268710042da5be700b80ef0de716fe089b8652c84f
+  languageName: node
+  linkType: hard
+
+"pg-pool@npm:^3.5.2, pg-pool@npm:^3.7.0":
   version: 3.7.0
   resolution: "pg-pool@npm:3.7.0"
   peerDependencies:
@@ -40846,7 +40873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-protocol@npm:*, pg-protocol@npm:^1.5.0":
+"pg-protocol@npm:*, pg-protocol@npm:^1.5.0, pg-protocol@npm:^1.7.0":
   version: 1.7.0
   resolution: "pg-protocol@npm:1.7.0"
   checksum: 10/ffffdf74426c9357b57050f1c191e84447c0e8b2a701b3ab302ac7dd0eb27b862d92e5e3b2d38876a1051de83547eb9165d6a58b3a8e90bb050dae97f9993d54
@@ -40863,6 +40890,43 @@ __metadata:
     postgres-date: "npm:~1.0.4"
     postgres-interval: "npm:^1.1.0"
   checksum: 10/87a84d4baa91378d3a3da6076c69685eb905d1087bf73525ae1ba84b291b9dd8738c6716b333d8eac6cec91bf087237adc3e9281727365e9cbab0d9d072778b1
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "pg-types@npm:4.0.2"
+  dependencies:
+    pg-int8: "npm:1.0.1"
+    pg-numeric: "npm:1.0.2"
+    postgres-array: "npm:~3.0.1"
+    postgres-bytea: "npm:~3.0.0"
+    postgres-date: "npm:~2.1.0"
+    postgres-interval: "npm:^3.0.0"
+    postgres-range: "npm:^1.1.1"
+  checksum: 10/f4d529da864d4169afab300eb8629a84a6a06aa70c471160a7e46c34b6d4dd0e61cbd57d10d98c3a36e98f474e2ff85d41e4b1c953a321146b4bae09372c58d3
+  languageName: node
+  linkType: hard
+
+"pg@npm:8.13.1":
+  version: 8.13.1
+  resolution: "pg@npm:8.13.1"
+  dependencies:
+    pg-cloudflare: "npm:^1.1.1"
+    pg-connection-string: "npm:^2.7.0"
+    pg-pool: "npm:^3.7.0"
+    pg-protocol: "npm:^1.7.0"
+    pg-types: "npm:^2.1.0"
+    pgpass: "npm:1.x"
+  peerDependencies:
+    pg-native: ">=3.0.1"
+  dependenciesMeta:
+    pg-cloudflare:
+      optional: true
+  peerDependenciesMeta:
+    pg-native:
+      optional: true
+  checksum: 10/542aa49fcb37657cf5f779b4a31fe6eb336e683445ecca38e267eeb0ca85d873ffe51f04794f9f9e184187e9f74bf7895e932a0fa9507132ac0dfc76c7c73451
   languageName: node
   linkType: hard
 
@@ -42162,10 +42226,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postgres-array@npm:~3.0.1":
+  version: 3.0.2
+  resolution: "postgres-array@npm:3.0.2"
+  checksum: 10/0159517e4e5f263bf9e324f0c4d3c10244a294021f2b5980abc8c23afdb965370a7fc0c82012fce4d28e83186ad089b6476b05fcef6c88f8e43e37a3a2fa0ad5
+  languageName: node
+  linkType: hard
+
 "postgres-bytea@npm:~1.0.0":
   version: 1.0.0
   resolution: "postgres-bytea@npm:1.0.0"
   checksum: 10/d844ae4ca7a941b70e45cac1261a73ee8ed39d72d3d74ab1d645248185a1b7f0ac91a3c63d6159441020f4e1f7fe64689ac56536a307b31cef361e5187335090
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~3.0.0":
+  version: 3.0.0
+  resolution: "postgres-bytea@npm:3.0.0"
+  dependencies:
+    obuf: "npm:~1.1.2"
+  checksum: 10/f5c01758fd2fa807afbd34e1ba2146f683818ebc2d23f4a62f0fd627c0b1126fc543cab1b63925f97ce6c7d8f5f316043218619c447445210ea82f10411efb1b
   languageName: node
   linkType: hard
 
@@ -42176,12 +42256,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postgres-date@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "postgres-date@npm:2.1.0"
+  checksum: 10/faa1c70dfad0e35bd4aa7cb6088fcd4e4f039aa25dc42150129178fc2a0baa7e37eca0bf18e4142a40dea18d1955459b08783f78ec487ef27b4b93ab5e854597
+  languageName: node
+  linkType: hard
+
 "postgres-interval@npm:^1.1.0":
   version: 1.2.0
   resolution: "postgres-interval@npm:1.2.0"
   dependencies:
     xtend: "npm:^4.0.0"
   checksum: 10/746b71f93805ae33b03528e429dc624706d1f9b20ee81bf743263efb6a0cd79ae02a642a8a480dbc0f09547b4315ab7df6ce5ec0be77ed700bac42730f5c76b2
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postgres-interval@npm:3.0.0"
+  checksum: 10/c7a1cf006de97de663b6b8c4d2b167aa9909a238c4866a94b15d303762f5ac884ff4796cd6e2111b7f0a91302b83c570453aa8506fd005b5a5d5dfa87441bebc
+  languageName: node
+  linkType: hard
+
+"postgres-range@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "postgres-range@npm:1.1.4"
+  checksum: 10/035759f17b44bf9ba7e71a30402ed2ca1e2b7fabb3ad794b08169a5b453d38d06905a6dfb51fe41a3f6d9fac4e183dac9e769b95053053db933be16785edce1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- refactored gateway argument in `storeLog`  & `storeProof` in gateway utils file.
- modified interface BLODispatcherOptions & SATPGatewayConfi , so that we can add the database connections, also injecting the dependencies of repository to the `SATPmanager` so the respective services have a way to store the logs.
- Improved SATP client and server stage services with databse logging.
- Added a new logging file to centralize and simplify log operations. (`logging.ts`)
- test on `packages/cactus-plugin-satp-hermes/src/test/typescript/unit/services.test.ts`

Addresses #3114 

**Pull Request Requirements**
- [X] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [X] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [X] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [X] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [X] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.