### PR TITLE
fix(weaver-publish-npm): corrected publish URLs

### DIFF
--- a/weaver/common/protos-js/package.json
+++ b/weaver/common/protos-js/package.json
@@ -51,7 +51,7 @@
     "npm": ">=8"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger"
+    "registry": "https://npm.pkg.github.com/hyperledger-cacti"
   },
   "licenses": [
     {

--- a/weaver/samples/fabric/fabric-cli/package-local.json
+++ b/weaver/samples/fabric/fabric-cli/package-local.json
@@ -64,8 +64,5 @@
   "engines": {
     "node": ">=18",
     "npm": ">=8"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger-labs"
   }
 }

--- a/weaver/samples/fabric/fabric-cli/package.json
+++ b/weaver/samples/fabric/fabric-cli/package.json
@@ -64,8 +64,5 @@
   "engines": {
     "node": ">=18",
     "npm": ">=8"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger-labs"
   }
 }

--- a/weaver/sdks/besu/node/package-local.json
+++ b/weaver/sdks/besu/node/package-local.json
@@ -37,7 +37,7 @@
     "npm": ">=8"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger"
+    "registry": "https://npm.pkg.github.com/hyperledger-cacti"
   },
   "tag": "latest"
 }

--- a/weaver/sdks/besu/node/package.json
+++ b/weaver/sdks/besu/node/package.json
@@ -37,7 +37,7 @@
     "npm": ">=8"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger"
+    "registry": "https://npm.pkg.github.com/hyperledger-cacti"
   },
   "tag": "latest"
 }

--- a/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
@@ -70,7 +70,7 @@
     "npm": ">=8"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger"
+    "registry": "https://npm.pkg.github.com/hyperledger-cacti"
   },
   "licenses": [
     {

--- a/weaver/sdks/fabric/interoperation-node-sdk/package.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package.json
@@ -70,7 +70,7 @@
     "npm": ">=8"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger"
+    "registry": "https://npm.pkg.github.com/hyperledger-cacti"
   },
   "licenses": [
     {


### PR DESCRIPTION
NPM registry references changed from `hyperledger` to `hyperledger-cacti`.
Removed unnecessary publish reference from `fabric-cli`, which is meant to be used purely for local testing and experiments.

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.