### PR TITLE
fix(test): add knex config in gateway

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage0-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage0-client-service.ts
@@ -381,7 +381,7 @@ export class Stage0ClientService extends SATPService {
     this.Log.info(`init-${stepTag}`);
     this.dbLogger.persistLogEntry({
       sessionID: sessionData.id,
-      type: "wrap-token",
+      type: "wrap-token-client",
       operation: "init",
       data: safeStableStringify(sessionData),
       sequenceNumber: Number(sessionData.lastSequenceNumber),
@@ -390,7 +390,7 @@ export class Stage0ClientService extends SATPService {
       this.Log.info(`exec-${stepTag}`);
       this.dbLogger.persistLogEntry({
         sessionID: sessionData.id,
-        type: "wrap-token",
+        type: "wrap-token-client",
         operation: "exec",
         data: safeStableStringify(sessionData),
         sequenceNumber: Number(sessionData.lastSequenceNumber),
@@ -441,7 +441,7 @@ export class Stage0ClientService extends SATPService {
 
       this.dbLogger.storeProof({
         sessionID: sessionData.id,
-        type: "wrap-token",
+        type: "wrap-token-client",
         operation: "done",
         data: safeStableStringify(sessionData.senderWrapAssertionClaim.proof),
         sequenceNumber: Number(sessionData.lastSequenceNumber),
@@ -451,7 +451,7 @@ export class Stage0ClientService extends SATPService {
       this.logger.debug(`Crash in ${fnTag}`, error);
       this.dbLogger.persistLogEntry({
         sessionID: sessionData.id,
-        type: "wrap-token",
+        type: "wrap-token-client",
         operation: "fail",
         data: safeStableStringify(sessionData),
         sequenceNumber: Number(sessionData.lastSequenceNumber),

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
@@ -254,7 +254,7 @@ export class Stage2ClientService extends SATPService {
       this.dbLogger.storeProof({
         sessionID: sessionData.id,
         type: "lock-asset",
-        operation: "done",
+        operation: "exec",
         data: safeStableStringify(sessionData),
         sequenceNumber: Number(sessionData.lastSequenceNumber),
       });

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage0-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage0-server-service.ts
@@ -517,7 +517,7 @@ export class Stage0ServerService extends SATPService {
     this.Log.info(`init-${stepTag}`);
     this.dbLogger.persistLogEntry({
       sessionID: sessionData.id,
-      type: "wrap-token",
+      type: "wrap-token-server",
       operation: "init",
       data: safeStableStringify(sessionData),
       sequenceNumber: Number(sessionData.lastSequenceNumber),
@@ -526,7 +526,7 @@ export class Stage0ServerService extends SATPService {
       this.Log.info(`exec-${stepTag}`);
       this.dbLogger.persistLogEntry({
         sessionID: sessionData.id,
-        type: "wrap-token",
+        type: "wrap-token-server",
         operation: "exec",
         data: safeStableStringify(sessionData),
         sequenceNumber: Number(sessionData.lastSequenceNumber),
@@ -574,7 +574,7 @@ export class Stage0ServerService extends SATPService {
 
       this.dbLogger.storeProof({
         sessionID: sessionData.id,
-        type: "wrap-token",
+        type: "wrap-token-server",
         operation: "done",
         data: safeStableStringify(sessionData.receiverWrapAssertionClaim.proof),
         sequenceNumber: Number(sessionData.lastSequenceNumber),
@@ -585,7 +585,7 @@ export class Stage0ServerService extends SATPService {
 
       this.dbLogger.persistLogEntry({
         sessionID: sessionData.id,
-        type: "wrap-token",
+        type: "wrap-token-server",
         operation: "fail",
         data: safeStableStringify(sessionData),
         sequenceNumber: Number(sessionData.lastSequenceNumber),

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
@@ -560,6 +560,18 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
 
     this.logger.info(`Closed ${connectionsClosed} connections`);
     this.logger.info("Gateway Coordinator shut down");
+
+    if (this.localRepository) {
+      this.logger.debug("Destroying local repository...");
+      await this.localRepository.destroy();
+      this.logger.info("Local repository destroyed");
+    }
+
+    if (this.remoteRepository) {
+      this.logger.debug("Destroying remote repository...");
+      await this.remoteRepository.destroy();
+      this.logger.info("Remote repository destroyed");
+    }
     return;
   }
 

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway-blo.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway-blo.test.ts
@@ -16,6 +16,10 @@ import {
 } from "../../../main/typescript/core/types";
 import { createClient } from "../test-utils";
 import { HealthCheckResponseStatusEnum } from "../../../main/typescript";
+import {
+  knexClientConnection,
+  knexSourceRemoteConnection,
+} from "../knex.config";
 
 const logLevel: LogLevelDesc = "DEBUG";
 const logger = LoggerProvider.getOrCreate({
@@ -57,6 +61,8 @@ const options: SATPGatewayConfig = {
     gatewayOpenAPIPort: 4010,
     address: "http://localhost",
   },
+  knexLocalConfig: knexClientConnection,
+  knexRemoteConfig: knexSourceRemoteConnection,
 };
 
 describe("GetStatus Endpoint and Functionality testing", () => {

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway-init-startup.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway-init-startup.test.ts
@@ -41,6 +41,10 @@ import {
 import { AddressInfo } from "net";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 import { AdminApi } from "../../../main/typescript";
+import {
+  knexClientConnection,
+  knexSourceRemoteConnection,
+} from "../knex.config";
 
 const logLevel: LogLevelDesc = "DEBUG";
 const logger = LoggerProvider.getOrCreate({
@@ -65,7 +69,10 @@ beforeAll(async () => {
 
 describe("SATPGateway initialization", () => {
   it("should initiate gateway with default config", async () => {
-    const options: SATPGatewayConfig = {};
+    const options: SATPGatewayConfig = {
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
+    };
     const gateway = await factory.create(options);
 
     expect(gateway).toBeInstanceOf(SATPGateway);
@@ -106,6 +113,8 @@ describe("SATPGateway initialization", () => {
         gatewayServerPort: 3010,
         address: "https://localhost",
       },
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
     };
     const gateway = await factory.create(options);
 
@@ -148,6 +157,8 @@ describe("SATPGateway initialization", () => {
         proofID: "mockProofID10",
         address: "https://localhost",
       },
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
     };
     const gateway = await factory.create(options);
     expect(gateway).toBeInstanceOf(SATPGateway);
@@ -179,6 +190,8 @@ describe("SATPGateway initialization", () => {
         gatewayClientPort: 3015,
         address: "https://localhost",
       },
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
     };
 
     const gateway = await factory.create(options);
@@ -219,7 +232,10 @@ describe("SATPGateway initialization", () => {
 
 describe("SATPGateway startup", () => {
   it("initiates with default config", async () => {
-    const options: SATPGatewayConfig = {};
+    const options: SATPGatewayConfig = {
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
+    };
     const gateway = await factory.create(options);
 
     expect(gateway).toBeInstanceOf(SATPGateway);
@@ -260,6 +276,8 @@ describe("SATPGateway startup", () => {
         gatewayClientPort: 3001,
         address: "https://localhost",
       },
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
     };
     const gateway = await factory.create(options);
 
@@ -306,6 +324,8 @@ describe("SATPGateway startup", () => {
         address: "http://localhost",
       },
       enableOpenAPI: true,
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
     };
     const gateway = await factory.create(options);
     expect(gateway).toBeInstanceOf(SATPGateway);

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-e2e-transfer-2-gateways-openapi.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-e2e-transfer-2-gateways-openapi.test.ts
@@ -42,7 +42,18 @@ import {
   SATP_CORE_VERSION,
   SATP_CRASH_VERSION,
 } from "../../../main/typescript/core/constants";
+import {
+  knexClientConnection,
+  knexSourceRemoteConnection,
+  knexTargetRemoteConnection,
+  knexServerConnection,
+} from "../knex.config";
+import { Knex, knex } from "knex";
 
+let knexInstanceClient: Knex;
+let knexSourceRemoteInstance: Knex;
+let knexTargetRemoteInstance: Knex;
+let knexInstanceServer: Knex;
 const logLevel: LogLevelDesc = "DEBUG";
 const log = LoggerProvider.getOrCreate({
   level: logLevel,
@@ -51,14 +62,31 @@ const log = LoggerProvider.getOrCreate({
 
 let fabricEnv: FabricTestEnvironment;
 let besuEnv: BesuTestEnvironment;
-let gateway1: SATPGateway;
-let gateway2: SATPGateway;
+let sourceGateway: SATPGateway;
+let targetGateway: SATPGateway;
 const bridge_id =
   "x509::/OU=org2/OU=client/OU=department1/CN=bridge::/C=UK/ST=Hampshire/L=Hursley/O=org2.example.com/CN=ca.org2.example.com";
 
 afterAll(async () => {
-  await gateway1.shutdown();
-  await gateway2.shutdown();
+  if (sourceGateway) {
+    if (knexInstanceClient) {
+      await knexInstanceClient.destroy();
+    }
+    if (knexSourceRemoteInstance) {
+      await knexSourceRemoteInstance.destroy();
+    }
+    await sourceGateway.shutdown();
+  }
+
+  if (targetGateway) {
+    if (knexTargetRemoteInstance) {
+      await knexTargetRemoteInstance.destroy();
+    }
+    if (knexInstanceServer) {
+      await knexInstanceServer.destroy();
+    }
+    await targetGateway.shutdown();
+  }
   await besuEnv.tearDown();
   await fabricEnv.tearDown();
 
@@ -152,6 +180,12 @@ describe("2 SATPGateway sending a token from Besu to Fabric using openApi to req
 
     const gateway2KeyPair = Secp256k1Keys.generateKeyPairsBuffer();
 
+    knexInstanceClient = knex(knexClientConnection);
+    await knexInstanceClient.migrate.latest();
+
+    knexSourceRemoteInstance = knex(knexSourceRemoteConnection);
+    await knexSourceRemoteInstance.migrate.latest();
+
     const options1: SATPGatewayConfig = {
       logLevel: "DEBUG",
       gid: gatewayIdentity1,
@@ -178,8 +212,15 @@ describe("2 SATPGateway sending a token from Besu to Fabric using openApi to req
       ],
       bridgesConfig: [besuEnv.besuConfig],
       keyPair: gateway1KeyPair,
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
     };
 
+    knexInstanceServer = knex(knexServerConnection);
+    await knexInstanceServer.migrate.latest();
+
+    knexTargetRemoteInstance = knex(knexTargetRemoteConnection);
+    await knexTargetRemoteInstance.migrate.latest();
     const options2: SATPGatewayConfig = {
       logLevel: "DEBUG",
       gid: gatewayIdentity2,
@@ -202,30 +243,32 @@ describe("2 SATPGateway sending a token from Besu to Fabric using openApi to req
       ],
       bridgesConfig: [fabricEnv.fabricConfig],
       keyPair: gateway2KeyPair,
+      knexLocalConfig: knexServerConnection,
+      knexRemoteConfig: knexTargetRemoteConnection,
     };
-    gateway1 = await factory.create(options1);
-    expect(gateway1).toBeInstanceOf(SATPGateway);
+    sourceGateway = await factory.create(options1);
+    expect(sourceGateway).toBeInstanceOf(SATPGateway);
 
-    const identity1 = gateway1.Identity;
+    const identity1 = sourceGateway.Identity;
     // default servers
     expect(identity1.gatewayServerPort).toBe(3010);
     expect(identity1.gatewayClientPort).toBe(3011);
     expect(identity1.gatewayOpenAPIPort).toBe(4010);
     expect(identity1.address).toBe("http://localhost");
-    await gateway1.startup();
+    await sourceGateway.startup();
 
-    gateway2 = await factory.create(options2);
-    expect(gateway2).toBeInstanceOf(SATPGateway);
+    targetGateway = await factory.create(options2);
+    expect(targetGateway).toBeInstanceOf(SATPGateway);
 
-    const identity2 = gateway2.Identity;
+    const identity2 = targetGateway.Identity;
     // default servers
     expect(identity2.gatewayServerPort).toBe(3110);
     expect(identity2.gatewayClientPort).toBe(3111);
     expect(identity2.gatewayOpenAPIPort).toBe(4110);
     expect(identity2.address).toBe("http://localhost");
-    await gateway2.startup();
+    await targetGateway.startup();
 
-    const dispatcher = gateway1.getBLODispatcher();
+    const dispatcher = sourceGateway.getBLODispatcher();
 
     expect(dispatcher).toBeTruthy();
     const req = getTransactRequest(

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/knex.config.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/knex.config.ts
@@ -28,11 +28,25 @@ export const knexServerConnection = {
   useNullAsDefault: true,
 };
 
-export const knexRemoteConnection = {
+export const knexSourceRemoteConnection = {
   client: "sqlite3",
   connection: {
     filename:
-      "./packages/cactus-plugin-satp-hermes/src/knex/.dev.remote-" +
+      "./packages/cactus-plugin-satp-hermes/src/knex/.dev.source-remote-" +
+      uuidv4() +
+      ".sqlite3",
+  },
+  migrations: {
+    directory: "./packages/cactus-plugin-satp-hermes/src/knex/migrations",
+  },
+  useNullAsDefault: true,
+};
+
+export const knexTargetRemoteConnection = {
+  client: "sqlite3",
+  connection: {
+    filename:
+      "./packages/cactus-plugin-satp-hermes/src/knex/.dev.target-remote-" +
       uuidv4() +
       ".sqlite3",
   },

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/services.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/services.test.ts
@@ -71,7 +71,10 @@ import {
   ILocalLogRepository,
   IRemoteLogRepository,
 } from "../../../main/typescript/repository/interfaces/repository";
-import { knexClientConnection, knexRemoteConnection } from "../knex.config";
+import {
+  knexClientConnection,
+  knexSourceRemoteConnection,
+} from "../knex.config";
 import { Knex, knex } from "knex";
 import { KnexLocalLogRepository as LocalLogRepository } from "../../../main/typescript/repository/knex-local-log-repository";
 import { KnexRemoteLogRepository as RemoteLogRepository } from "../../../main/typescript/repository/knex-remote-log-repository";
@@ -146,11 +149,11 @@ beforeAll(async () => {
   knexInstanceClient = knex(knexClientConnection);
   await knexInstanceClient.migrate.latest();
 
-  knexInstanceRemote = knex(knexRemoteConnection);
+  knexInstanceRemote = knex(knexSourceRemoteConnection);
   await knexInstanceRemote.migrate.latest();
 
   localRepository = new LocalLogRepository(knexClientConnection);
-  remoteRepository = new RemoteLogRepository(knexRemoteConnection);
+  remoteRepository = new RemoteLogRepository(knexSourceRemoteConnection);
   dbLogger = new SATPLogger({
     localRepository,
     remoteRepository,


### PR DESCRIPTION
1.Integrated knexLocalConfig and knexRemoteConfig into SATPGatewayConfig

Fixes https://github.com/hyperledger-cacti/cacti/pull/3665

Signed-off-by: Yogesh01000100 <yogeshone678@gmail.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.