### PR TITLE
ci(weaver): update network-setups fabric setupCC.sh

### DIFF
--- a/weaver/tests/network-setups/fabric/dev/scripts/setupCC.sh
+++ b/weaver/tests/network-setups/fabric/dev/scripts/setupCC.sh
@@ -4,7 +4,8 @@
 
 directory=$(dirname $0)
 
-CACTI_VERSION=v2.0.0
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CACTI_VERSION="v$(head -n 1 $SCRIPT_DIR/../../../../../core/network/fabric-interop-cc/contracts/interop/VERSION)"
 TMP_PATH=$PWD/../shared/tmp
 CHAINCODE_PATH=$PWD/../shared/chaincode
 rm -rf $CHAINCODE_PATH/interop


### PR DESCRIPTION
Primary Changes
---------------
1. Fixed network-setups fabric setupCC.sh:
weaver/tests/network-setups/fabric/dev/scripts/setupCC.sh

Peter's Changes
---------------
1. Fixed the commit message syntax so that it passes the linter

Fixes: #3679

Co-Authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Signed-off-by: Daiki.Nakashima <Nakashima.Daiki@df.MitsubishiElectric.co.jp>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.