### PR TITLE
ci(github): update publishing workflows to use github.repository_owner

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -62,8 +62,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
-          git config --global user.email "npm-ci@hyperledger.org"
-          git config --global user.name "hyperledger-ghci"
           npm whoami
           yarn lerna publish from-git --yes --loglevel=debug --ignore-scripts
 
@@ -98,7 +96,7 @@ jobs:
 
       - name: Configure git user and email
         run: |
-          git config --global user.email "npm-ci@hyperledger.org"
+          git config --global user.email "npm-ci@${{ github.repository_owner }}.org"
           git config --global user.name "hyperledger-ghci"
 
       # We run the publish script a second time after having reconfigured the registry to be GHCR

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -43,7 +43,5 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         NPM_CONFIG_PROVENANCE: true
       run: |
-        git config --global user.email "npm-ci@hyperledger.org"
-        git config --global user.name "hyperledger-ghci"
         npm whoami
         yarn lerna publish from-git --yes --loglevel=debug


### PR DESCRIPTION
Primary Changes
----------------
1. Updated publishing workflows to use gitHub.repository_owner variable

Fixes #3597

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.