### PR TITLE
ci(github): fix type exports in packages/cacti-plugin-copm-fabric

### DIFF
--- a/tools/custom-checks/get-all-tgz-path.ts
+++ b/tools/custom-checks/get-all-tgz-path.ts
@@ -46,12 +46,14 @@ export async function getAllTgzPath(): Promise<IGetAllTgzPathResponse> {
       "weaver/sdks/fabric/interoperation-node-sdk/hyperledger-cacti-weaver-sdk-fabric-*.tgz",
       // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3628
       "packages/cacti-plugin-weaver-driver-fabric/src/main/typescript/hyperledger-cacti-weaver-driver-fabric-*.tgz",
-      // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3629
-      "packages/cacti-plugin-copm-fabric/hyperledger-cacti-cacti-plugin-copm-fabric-*.tgz",
       // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3632
       "examples/cactus-common-example-server/hyperledger-cactus-common-example-server-*.tgz",
       // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3633
       "packages/cactus-verifier-client/hyperledger-cactus-verifier-client-*.tgz",
+      // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3740
+      "examples/cactus-example-discounted-asset-trade/hyperledger-cactus-example-discounted-asset-trade-*.tgz",
+      // link for issue ticket relating to this package: https://github.com/hyperledger-cacti/cacti/issues/3741
+      "examples/cactus-example-electricity-trade/hyperledger-cactus-example-electricity-trade-*.tgz",
     ],
   };
 


### PR DESCRIPTION
### Commit to be reviewed
---
ci(github): fix type exports in packages/cacti-plugin-copm-fabric
```
Primary Changes
---------------
1. Removed packages/cacti-plugin-copm-fabric/hyperledger-cacti-cacti-plugin-
copm-fabric-*.tgz in ignore paths in get-all-tgz-path.ts file
2. Added main, module, types, and files in package.json
3. While fixing merge conflict, discovered new packages failing and added
on ignore path and created tickets for it
```

Fixes: #3629

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.