### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/.dast-nuclei-cmd-api-server.yaml
+++ b/.github/workflows/.dast-nuclei-cmd-api-server.yaml
@@ -124,7 +124,7 @@ jobs:
         run: "nuclei -list=urls.txt -dast -severity=high,critical -sarif-export ~/nuclei.sarif -output=nuclei.log"
 
       - name: GitHub Workflow artifacts
-        uses: actions/upload-artifact@v3.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: nuclei.log
           path: nuclei.log

--- a/.github/workflows/ghpkg-all-kotlin-api-clients-publish.yaml
+++ b/.github/workflows/ghpkg-all-kotlin-api-clients-publish.yaml
@@ -61,7 +61,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-ledger-connector-corda-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-ledger-connector-corda-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-ledger-connector-corda/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -75,7 +75,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-cmd-api-server-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-cmd-api-server-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-cmd-api-server/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -89,7 +89,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-core-api-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-core-api-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-core-api/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -103,7 +103,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-consortium-manual-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-consortium-manual-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-consortium-manual/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -117,7 +117,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-keychain-google-sm-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-keychain-google-sm-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-keychain-google-sm/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -131,7 +131,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-keychain-aws-sm-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-keychain-aws-sm-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-keychain-aws-sm/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -145,7 +145,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-keychain-azure-kv-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-keychain-azure-kv-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-keychain-azure-kv/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -159,7 +159,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-keychain-memory-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-keychain-memory-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-keychain-memory/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -173,7 +173,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-keychain-vault-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-keychain-vault-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-keychain-vault/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -187,7 +187,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-ledger-connector-fabric-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-ledger-connector-fabric-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-ledger-connector-fabric/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -201,7 +201,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-keychain-memory-wasm-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-keychain-memory-wasm-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-keychain-memory-wasm/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -215,7 +215,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-satp-hermes-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-satp-hermes-kotlin-client-${{ env.GITVERSION }}.jar
         path: packages/cactus-plugin-satp-hermes/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -229,7 +229,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-example-supply-chain-business-logic-plugin-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-example-supply-chain-business-logic-plugin-kotlin-client-${{ env.GITVERSION }}.jar
         path: examples/cactus-example-supply-chain-business-logic-plugin/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -243,7 +243,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-example-carbon-accounting-business-logic-plugin-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-example-carbon-accounting-business-logic-plugin-kotlin-client-${{ env.GITVERSION }}.jar
         path: examples/cactus-example-carbon-accounting-business-logic-plugin/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar
@@ -257,7 +257,7 @@ jobs:
         ./gradlew build
 
     - name: publish-cactus-plugin-object-store-ipfs-kotlin-client
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: cactus-plugin-object-store-ipfs-kotlin-client-${{ env.GITVERSION }}.jar
         path: extensions/cactus-plugin-object-store-ipfs/src/main/kotlin/generated/openapi/kotlin-client/build/libs/kotlin-client-1.0.0.jar


### PR DESCRIPTION
actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).
