### PR TITLE
chore(satp-hermes): add maintainers to satp-hermes package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,18 @@
 * @petermetz @takeutak @izuru0 @jagpreetsinghsasan @vramakrishna @sandeepnRES @outSH
 
+packages/cactus-plugin-ccmodel-hephaestus @RafaelAPB
 packages/cactus-plugin-satp-hermes @RafaelAPB
 packages/cactus-plugin-bungee-hermes @RafaelAPB
 examples/cactus-example-cbdc-bridging @RafaelAPB
 examples/cactus-example-cbdc-bridging-backend @RafaelAPB
 examples/cactus-example-cbdc-bridging-frontend @RafaelAPB
+packages/cactus-plugin-satp-hermes @LordKubaya
+packages/cactus-plugin-bungee-hermes @LordKubaya
+examples/cactus-example-cbdc-bridging @LordKubaya
+examples/cactus-example-cbdc-bridging-backend @LordKubaya
+examples/cactus-example-cbdc-bridging-frontend @LordKubaya
+packages/cactus-plugin-satp-hermes @AndreAugusto11
+packages/cactus-plugin-bungee-hermes @AndreAugusto11
+examples/cactus-example-cbdc-bridging @AndreAugusto11
+examples/cactus-example-cbdc-bridging-backend @AndreAugusto11
+examples/cactus-example-cbdc-bridging-frontend @AndreAugusto11


### PR DESCRIPTION
chore(satp-hermes): add maintainers to satp-hermes package

This PR adds @LordKubaya and @AndreAugusto11 as maintainers for the `satp-hermes` package.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.

[skip ci]