### PR TITLE
ci(all-nodejs-packages-publish): restrict job trigger pattern to semver

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -24,6 +24,18 @@ jobs:
     permissions: 
       id-token: write
     steps:
+      - name: Check Version Format in Tag
+        uses: nowsprinting/check-version-format-action@v4.0.5
+        id: version
+        with:
+          prefix: 'v'
+
+      - name: Fail if version is invalid
+        if: steps.version.outputs.is_valid != 'true'
+        run: |
+          echo "Error: Tag '${{ github.ref_name }}' is not a valid semantic version."
+          exit 1
+
       - name: Print Workflow inputs.GIT_TAG_TO_PUBLISH
         run: |
           echo "inputs.GIT_TAG_TO_PUBLISH=${{ inputs.GIT_TAG_TO_PUBLISH }}" 


### PR DESCRIPTION
Primary Changes
----------------
1. Added semver validation to all-nodejs-packages-publish.yaml

Fixes #2385

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.