### PR TITLE
test(htlc-eth-besu-erc20): migrate refund-endpoint test cases from Tape to Jest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2008,8 +2008,7 @@ jobs:
       JEST_TEST_RUNNER_DISABLED: false
       JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ctp-htlc-eth-besu-erc20
       JEST_TEST_CODE_COVERAGE_ENABLED: true
-      TAPE_TEST_PATTERN: >-
-        --files={./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts,./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts}
+      TAPE_TEST_PATTERN: ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
     runs-on: ubuntu-22.04

--- a/.taprc
+++ b/.taprc
@@ -9,7 +9,6 @@ files:
   - ./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts
   - ./packages/cactus-plugin-keychain-azure-kv/src/test/typescript/integration/plugin-keychain-azure-kv.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts
-  - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts
   - ./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/flow-database-access-v4.8.test.ts
   - ./packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/openapi/openapi-validation.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,6 @@ module.exports = {
     `./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts`,
     `./packages/cactus-plugin-keychain-azure-kv/src/test/typescript/integration/plugin-keychain-azure-kv.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts`,
-    `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts`,
     `./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/flow-database-access-v4.8.test.ts`,
     `./packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/openapi/openapi-validation.test.ts`,

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
@@ -1,7 +1,8 @@
-import http from "http";
-import type { AddressInfo } from "net";
-import test, { Test } from "tape-promise/tape";
-import { v4 as uuidv4 } from "uuid";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { randomUUID as uuidv4 } from "node:crypto";
+
+import "jest-extended";
 import express from "express";
 import bodyParser from "body-parser";
 import {
@@ -24,63 +25,41 @@ import {
   LogLevelDesc,
   IListenOptions,
   Servers,
+  LoggerProvider,
 } from "@hyperledger/cactus-common";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 import { PluginImportType } from "@hyperledger/cactus-core-api";
 import {
   BesuTestLedger,
-  BESU_TEST_LEDGER_DEFAULT_OPTIONS,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
+
 import TestTokenJSON from "../../../solidity/token-erc20-contract/Test_Token.json";
 import DemoHelperJSON from "../../../solidity/token-erc20-contract/DemoHelpers.json";
 import HashTimeLockJSON from "../../../../../../cactus-plugin-htlc-eth-besu-erc20/src/main/solidity/contracts/HashedTimeLockContract.json";
 
-const logLevel: LogLevelDesc = "INFO";
-const estimatedGas = 6721975;
-const besuTestLedger = new BesuTestLedger({ logLevel });
-const receiver = besuTestLedger.getGenesisAccountPubKey();
-const hashLock =
-  "0x3c335ba7f06a8b01d0596589f73c19069e21c81e5013b91f408165d1bf623d32";
-const firstHighNetWorthAccount = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1";
-const privateKey =
-  "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d";
-const connectorId = uuidv4();
-const web3SigningCredential: Web3SigningCredential = {
-  ethAccount: firstHighNetWorthAccount,
-  secret: privateKey,
-  type: Web3SigningCredentialType.PrivateKeyHex,
-} as Web3SigningCredential;
+describe("HTLC ETH Besu ERC-20 refund-endpoint", () => {
+  const logLevel: LogLevelDesc = "INFO";
+  const estimatedGas = 6721975;
+  const besuTestLedger = new BesuTestLedger({ logLevel });
+  const receiver = besuTestLedger.getGenesisAccountPubKey();
+  const hashLock =
+    "0x3c335ba7f06a8b01d0596589f73c19069e21c81e5013b91f408165d1bf623d32";
+  const firstHighNetWorthAccount = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1";
+  const privateKey =
+    "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d";
+  const connectorId = uuidv4();
+  const web3SigningCredential: Web3SigningCredential = {
+    ethAccount: firstHighNetWorthAccount,
+    secret: privateKey,
+    type: Web3SigningCredentialType.PrivateKeyHex,
+  } as Web3SigningCredential;
 
-const timeout = (ms: number) => {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-};
+  const timeout = (ms: number) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
 
-const testCase = "Test refund endpoint";
-
-test("BEFORE " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
-  t.end();
-});
-
-test(testCase, async (t: Test) => {
-  t.comment("Starting Besu Test Ledger");
-  const besuTestLedger = new BesuTestLedger({
-    logLevel,
-    envVars: [...BESU_TEST_LEDGER_DEFAULT_OPTIONS.envVars, "BESU_LOGGING=ALL"],
-  });
-  await besuTestLedger.start();
-
-  test.onFinish(async () => {
-    await besuTestLedger.stop();
-    await besuTestLedger.destroy();
-    await pruneDockerAllIfGithubAction({ logLevel });
-  });
-
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
   const keychainId = uuidv4();
   const keychainPlugin = new PluginKeychainMemory({
     instanceId: uuidv4(),
@@ -93,489 +72,240 @@ test(testCase, async (t: Test) => {
     ]),
     logLevel,
   });
-  keychainPlugin.set(
-    DemoHelperJSON.contractName,
-    JSON.stringify(DemoHelperJSON),
-  );
-  keychainPlugin.set(
-    HashTimeLockJSON.contractName,
-    JSON.stringify(HashTimeLockJSON),
-  );
-  const factory = new PluginFactoryLedgerConnector({
-    pluginImportType: PluginImportType.Local,
+
+  const log = LoggerProvider.getOrCreate({
+    label: "refund-endpoint.test.ts",
+    level: "INFO",
   });
 
-  const pluginRegistry = new PluginRegistry({});
-  const connector: PluginLedgerConnectorBesu = await factory.create({
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    logLevel,
-    instanceId: connectorId,
-    pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
-  });
+  let server: http.Server;
+  let api: BesuApi;
 
-  pluginRegistry.add(connector);
-  const pluginOptions: IPluginHtlcEthBesuErc20Options = {
-    instanceId: uuidv4(),
-    logLevel,
-    pluginRegistry,
-  };
-
-  const factoryHTLC = new PluginFactoryHtlcEthBesuErc20({
-    pluginImportType: PluginImportType.Local,
+  beforeAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
   });
-  const pluginHtlc = await factoryHTLC.create(pluginOptions);
-  pluginRegistry.add(pluginHtlc);
 
   const expressApp = express();
   expressApp.use(bodyParser.json({ limit: "250mb" }));
-  const server = http.createServer(expressApp);
-  const listenOptions: IListenOptions = {
-    hostname: "127.0.0.1",
-    port: 0,
-    server,
-  };
-  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
-  test.onFinish(async () => await Servers.shutdown(server));
-  const { address, port } = addressInfo;
-  const apiHost = `http://${address}:${port}`;
+  server = http.createServer(expressApp);
 
-  const configuration = new Configuration({ basePath: apiHost });
-  const api = new BesuApi(configuration);
-
-  await pluginHtlc.getOrCreateWebServices();
-  await pluginHtlc.registerWebServices(expressApp);
-
-  t.comment("Deploys HashTimeLock via .json file on initialize function");
-  const initRequest: InitializeRequest = {
-    connectorId,
-    keychainId,
-    constructorArgs: [],
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const deployOut = await pluginHtlc.initialize(initRequest);
-
-  t.ok(deployOut, "pluginHtlc.initialize() output is truthy OK");
-  t.ok(
-    deployOut.transactionReceipt,
-    "pluginHtlc.initialize() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOut.transactionReceipt.contractAddress,
-    "pluginHtlc.initialize() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const hashTimeLockAddress = deployOut.transactionReceipt
-    .contractAddress as string;
-
-  t.comment("Deploys TestToken via .json file on deployContract function");
-  const deployOutToken = await connector.deployContract({
-    contractName: TestTokenJSON.contractName,
-    contractAbi: TestTokenJSON.abi,
-    bytecode: TestTokenJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: ["100", "token", "2", "TKN"],
-    gas: estimatedGas,
+  beforeAll(async () => {
+    server = http.createServer(expressApp);
+    await besuTestLedger.start();
   });
-  t.ok(deployOutToken, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutToken.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutToken.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const tokenAddress = deployOutToken.transactionReceipt
-    .contractAddress as string;
 
-  t.comment("Deploys DemoHelpers via .json file on deployContract function");
-  const deployOutDemo = await connector.deployContract({
-    contractName: DemoHelperJSON.contractName,
-    contractAbi: DemoHelperJSON.abi,
-    bytecode: DemoHelperJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: [],
-    gas: estimatedGas,
-  });
-  t.ok(deployOutDemo, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutDemo.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutDemo.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
-
-  t.comment("Approve 10 Tokens to HashTimeLockAddress");
-  const { success } = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Send,
-    methodName: "approve",
-    params: [hashTimeLockAddress, "10"],
-    gas: estimatedGas,
-  });
-  t.equal(success, true, "approve() transactionReceipt.status is true OK");
-
-  t.comment("Get account balance");
-  const responseBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(responseBalance.callOutput, "100", "balance of account is 100 OK");
-
-  t.comment("Get current timestamp");
-  const { callOutput } = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTimestamp",
-    params: [],
-  });
-  t.ok(callOutput, "callOutput() output.callOutput is truthy OK");
-  let timestamp = 0;
-  timestamp = callOutput as number;
-  timestamp = +timestamp + +10;
-
-  t.comment("Get HashTimeLock contract and account allowance");
-  const responseAllowance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "allowance",
-    params: [firstHighNetWorthAccount, hashTimeLockAddress],
-  });
-  t.equal(responseAllowance.callOutput, "10", "callOutput() is 10 OK");
-
-  t.comment("Create new contract for HTLC");
-  const request: NewContractRequest = {
-    contractAddress: hashTimeLockAddress,
-    inputAmount: 10,
-    outputAmount: 1,
-    expiration: timestamp,
-    hashLock,
-    tokenAddress,
-    receiver,
-    outputNetwork: "BTC",
-    outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
-    connectorId,
-    keychainId,
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const res = await api.newContractV1(request);
-  t.equal(res.status, 200, "response status is 200 OK");
-
-  t.comment("Get account balance");
-  const responseBalance2 = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(responseBalance2.callOutput, "90", "balance of account is 90 OK");
-
-  t.comment("Get HTLC Id from DemoHelper");
-  const responseTxId = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTxId",
-    params: [
-      firstHighNetWorthAccount,
-      receiver,
-      10,
-      hashLock,
-      timestamp,
-      tokenAddress,
-    ],
-  });
-  t.ok(responseTxId.callOutput, "result is truthy OK");
-  const id = responseTxId.callOutput as string;
-
-  t.comment("Refund HTLC");
-  await timeout(6000);
-  const refundRequest: RefundRequest = {
-    id,
-    web3SigningCredential,
-    connectorId,
-    keychainId,
-  };
-  const resRefund = await api.refundV1(refundRequest);
-  t.equal(resRefund.status, 200, "response status is 200 OK");
-
-  t.comment("Get account balance");
-  const responseFinalBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(
-    responseFinalBalance.callOutput,
-    "100",
-    "balance of account is 100 OK",
-  );
-  t.comment("Get status of HTLC");
-  const resStatus = await api.getSingleStatusV1({
-    id,
-    web3SigningCredential,
-    connectorId,
-    keychainId,
-  });
-  t.equal(resStatus.status, 200, "response status is 200 OK");
-  t.equal(resStatus.data, 2, "the contract status is 2 - Refunded");
-  t.end();
-});
-
-test("Test invalid refund with invalid time", async (t: Test) => {
-  t.comment("Starting Besu Test Ledger");
-  const besuTestLedger = new BesuTestLedger({
-    logLevel,
-    envVars: [...BESU_TEST_LEDGER_DEFAULT_OPTIONS.envVars, "BESU_LOGGING=ALL"],
-  });
-  await besuTestLedger.start();
-
-  test.onFinish(async () => {
+  afterAll(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
   });
 
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
-  const keychainId = uuidv4();
-  const keychainPlugin = new PluginKeychainMemory({
-    instanceId: uuidv4(),
-    keychainId,
-    // pre-provision keychain with mock backend holding the private key of the
-    // test account that we'll reference while sending requests with the
-    // signing credential pointing to this keychain entry.
-    backend: new Map([
-      [TestTokenJSON.contractName, JSON.stringify(TestTokenJSON)],
-    ]),
-    logLevel,
-  });
-  keychainPlugin.set(
-    DemoHelperJSON.contractName,
-    JSON.stringify(DemoHelperJSON),
-  );
-  keychainPlugin.set(
-    HashTimeLockJSON.contractName,
-    JSON.stringify(HashTimeLockJSON),
-  );
-  const factory = new PluginFactoryLedgerConnector({
-    pluginImportType: PluginImportType.Local,
+  afterAll(async () => await Servers.shutdown(server));
+
+  afterAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
   });
 
-  const pluginRegistry = new PluginRegistry({});
-  const connector: PluginLedgerConnectorBesu = await factory.create({
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    logLevel,
-    instanceId: connectorId,
-    pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+  beforeAll(async () => {
+    await keychainPlugin.set(
+      DemoHelperJSON.contractName,
+      JSON.stringify(DemoHelperJSON),
+    );
+    await keychainPlugin.set(
+      HashTimeLockJSON.contractName,
+      JSON.stringify(HashTimeLockJSON),
+    );
   });
 
-  pluginRegistry.add(connector);
-  const pluginOptions: IPluginHtlcEthBesuErc20Options = {
-    instanceId: uuidv4(),
-    logLevel,
-    pluginRegistry,
-  };
+  it("correctly handles refunds", async () => {
+    const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
+    const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
 
-  const factoryHTLC = new PluginFactoryHtlcEthBesuErc20({
-    pluginImportType: PluginImportType.Local,
-  });
-  const pluginHtlc = await factoryHTLC.create(pluginOptions);
-  pluginRegistry.add(pluginHtlc);
+    const factory = new PluginFactoryLedgerConnector({
+      pluginImportType: PluginImportType.Local,
+    });
 
-  const expressApp = express();
-  expressApp.use(bodyParser.json({ limit: "250mb" }));
-  const server = http.createServer(expressApp);
-  const listenOptions: IListenOptions = {
-    hostname: "127.0.0.1",
-    port: 0,
-    server,
-  };
-  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
-  test.onFinish(async () => await Servers.shutdown(server));
-  const { address, port } = addressInfo;
-  const apiHost = `http://${address}:${port}`;
+    const pluginRegistry = new PluginRegistry({});
+    const connector: PluginLedgerConnectorBesu = await factory.create({
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      logLevel,
+      instanceId: connectorId,
+      pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+    });
 
-  const configuration = new Configuration({ basePath: apiHost });
-  const api = new BesuApi(configuration);
+    pluginRegistry.add(connector);
+    const pluginOptions: IPluginHtlcEthBesuErc20Options = {
+      instanceId: uuidv4(),
+      logLevel,
+      pluginRegistry,
+    };
 
-  await pluginHtlc.getOrCreateWebServices();
-  await pluginHtlc.registerWebServices(expressApp);
+    const factoryHTLC = new PluginFactoryHtlcEthBesuErc20({
+      pluginImportType: PluginImportType.Local,
+    });
+    const pluginHtlc = await factoryHTLC.create(pluginOptions);
+    pluginRegistry.add(pluginHtlc);
 
-  t.comment("Deploys HashTimeLock via .json file on initialize function");
-  const initRequest: InitializeRequest = {
-    connectorId,
-    keychainId,
-    constructorArgs: [],
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const deployOut = await pluginHtlc.initialize(initRequest);
+    const listenOptions: IListenOptions = {
+      hostname: "127.0.0.1",
+      port: 0,
+      server,
+    };
+    const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+    const { address, port } = addressInfo;
+    const apiHost = `http://${address}:${port}`;
 
-  t.ok(deployOut, "pluginHtlc.initialize() output is truthy OK");
-  t.ok(
-    deployOut.transactionReceipt,
-    "pluginHtlc.initialize() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOut.transactionReceipt.contractAddress,
-    "pluginHtlc.initialize() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const hashTimeLockAddress = deployOut.transactionReceipt
-    .contractAddress as string;
+    const configuration = new Configuration({ basePath: apiHost });
+    api = new BesuApi(configuration);
 
-  t.comment("Deploys TestToken via .json file on deployContract function");
-  const deployOutToken = await connector.deployContract({
-    contractName: TestTokenJSON.contractName,
-    contractAbi: TestTokenJSON.abi,
-    bytecode: TestTokenJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: ["100", "token", "2", "TKN"],
-    gas: estimatedGas,
-  });
-  t.ok(deployOutToken, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutToken.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutToken.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const tokenAddress = deployOutToken.transactionReceipt
-    .contractAddress as string;
+    await pluginHtlc.getOrCreateWebServices();
+    await pluginHtlc.registerWebServices(expressApp);
 
-  t.comment("Deploys DemoHelpers via .json file on deployContract function");
-  const deployOutDemo = await connector.deployContract({
-    contractName: DemoHelperJSON.contractName,
-    contractAbi: DemoHelperJSON.abi,
-    bytecode: DemoHelperJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: [],
-    gas: estimatedGas,
-  });
-  t.ok(deployOutDemo, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutDemo.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutDemo.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
+    const initRequest: InitializeRequest = {
+      connectorId,
+      keychainId,
+      constructorArgs: [],
+      web3SigningCredential,
+      gas: estimatedGas,
+    };
+    const deployOut = await pluginHtlc.initialize(initRequest);
 
-  t.comment("Approve 10 Tokens to HashTimeLockAddress");
-  const { success } = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Send,
-    methodName: "approve",
-    params: [hashTimeLockAddress, "10"],
-    gas: estimatedGas,
-  });
-  t.equal(success, true, "approve() transactionReceipt.status is true OK");
+    expect(deployOut).toBeTruthy();
+    expect(deployOut.transactionReceipt).toBeTruthy();
+    expect(deployOut.transactionReceipt.contractAddress).toBeTruthy();
 
-  t.comment("Get account balance");
-  const responseBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(responseBalance.callOutput, "100", "balance of account is 100 OK");
+    const hashTimeLockAddress = deployOut.transactionReceipt
+      .contractAddress as string;
+    const deployOutToken = await connector.deployContract({
+      contractName: TestTokenJSON.contractName,
+      contractAbi: TestTokenJSON.abi,
+      bytecode: TestTokenJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: ["100", "token", "2", "TKN"],
+      gas: estimatedGas,
+    });
 
-  t.comment("Get current timestamp");
-  const { callOutput } = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTimestamp",
-    params: [],
-  });
-  t.ok(callOutput, "callOutput() output.callOutput is truthy OK");
-  let timestamp = 0;
-  timestamp = callOutput as number;
-  timestamp = +timestamp + +10;
+    expect(deployOutToken).toBeTruthy();
+    expect(deployOutToken.transactionReceipt).toBeTruthy();
+    expect(deployOutToken.transactionReceipt.contractAddress).toBeTruthy();
 
-  t.comment("Get HashTimeLock contract and account allowance");
-  const responseAllowance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "allowance",
-    params: [firstHighNetWorthAccount, hashTimeLockAddress],
-  });
-  t.equal(responseAllowance.callOutput, "10", "callOutput() is 10 OK");
+    const tokenAddress = deployOutToken.transactionReceipt
+      .contractAddress as string;
+    const deployOutDemo = await connector.deployContract({
+      contractName: DemoHelperJSON.contractName,
+      contractAbi: DemoHelperJSON.abi,
+      bytecode: DemoHelperJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: [],
+      gas: estimatedGas,
+    });
 
-  t.comment("Create new contract for HTLC");
-  const request: NewContractRequest = {
-    contractAddress: hashTimeLockAddress,
-    inputAmount: 10,
-    outputAmount: 1,
-    expiration: timestamp,
-    hashLock,
-    tokenAddress,
-    receiver,
-    outputNetwork: "BTC",
-    outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
-    connectorId,
-    keychainId,
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const res = await api.newContractV1(request);
-  t.equal(res.status, 200, "response status is 200 OK");
+    expect(deployOutDemo).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt.contractAddress).toBeTruthy();
 
-  t.comment("Get HTLC Id from DemoHelper");
-  const responseTxId = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTxId",
-    params: [
-      firstHighNetWorthAccount,
-      receiver,
-      10,
+    const { success } = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Send,
+      methodName: "approve",
+      params: [hashTimeLockAddress, "10"],
+      gas: estimatedGas,
+    });
+    expect(success).toBe(true);
+
+    const responseBalance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+
+    expect(responseBalance.callOutput).toEqual("100");
+
+    const { callOutput } = await connector.invokeContract({
+      contractName: DemoHelperJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "getTimestamp",
+      params: [],
+    });
+
+    expect(callOutput).toBeTruthy();
+
+    let timestamp = 0;
+    timestamp = callOutput as number;
+    timestamp = +timestamp + +10;
+
+    const responseAllowance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "allowance",
+      params: [firstHighNetWorthAccount, hashTimeLockAddress],
+    });
+
+    expect(responseAllowance.callOutput).toEqual("10");
+
+    const request: NewContractRequest = {
+      contractAddress: hashTimeLockAddress,
+      inputAmount: 10,
+      outputAmount: 1,
+      expiration: timestamp,
       hashLock,
-      timestamp,
       tokenAddress,
-    ],
-  });
-  t.ok(responseTxId.callOutput, "result is truthy OK");
-  const id = responseTxId.callOutput as string;
+      receiver,
+      outputNetwork: "BTC",
+      outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
+      connectorId,
+      keychainId,
+      web3SigningCredential,
+      gas: estimatedGas,
+    };
+    const res = await api.newContractV1(request);
 
-  t.comment("Refund HTLC when it is not possible yet");
-  try {
+    expect(res.status).toEqual(200);
+
+    const responseBalance2 = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+
+    expect(responseBalance2.callOutput).toEqual("90");
+
+    const responseTxId = await connector.invokeContract({
+      contractName: DemoHelperJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "getTxId",
+      params: [
+        firstHighNetWorthAccount,
+        receiver,
+        10,
+        hashLock,
+        timestamp,
+        tokenAddress,
+      ],
+    });
+    expect(responseTxId.callOutput).toBeTruthy();
+
+    const id = responseTxId.callOutput as string;
+
+    await timeout(6000);
     const refundRequest: RefundRequest = {
       id,
       web3SigningCredential,
@@ -583,20 +313,221 @@ test("Test invalid refund with invalid time", async (t: Test) => {
       keychainId,
     };
     const resRefund = await api.refundV1(refundRequest);
-    t.equal(resRefund.status, 400, "response status is 400");
-  } catch (error) {
-    t.equal(error.response.status, 400, "response status is 400");
-  }
 
-  t.comment("Get balance of account");
-  const responseFinalBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
+    expect(resRefund.status).toEqual(200);
+
+    const responseFinalBalance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+
+    expect(responseFinalBalance.callOutput).toEqual("100");
+
+    const resStatus = await api.getSingleStatusV1({
+      id,
+      web3SigningCredential,
+      connectorId,
+      keychainId,
+    });
+
+    expect(resStatus.status).toEqual(200);
+    expect(resStatus.data).toEqual(2);
   });
-  t.equal(responseFinalBalance.callOutput, "90", "balance of account is 90 OK");
-  t.end();
+
+  it("handles invalid refund with invalid time", async () => {
+    const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
+    const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
+    const factory = new PluginFactoryLedgerConnector({
+      pluginImportType: PluginImportType.Local,
+    });
+
+    const pluginRegistry = new PluginRegistry({});
+    const connector: PluginLedgerConnectorBesu = await factory.create({
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      logLevel,
+      instanceId: connectorId,
+      pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+    });
+
+    pluginRegistry.add(connector);
+    const pluginOptions: IPluginHtlcEthBesuErc20Options = {
+      instanceId: uuidv4(),
+      logLevel,
+      pluginRegistry,
+    };
+
+    const factoryHTLC = new PluginFactoryHtlcEthBesuErc20({
+      pluginImportType: PluginImportType.Local,
+    });
+    const pluginHtlc = await factoryHTLC.create(pluginOptions);
+    pluginRegistry.add(pluginHtlc);
+
+    await pluginHtlc.getOrCreateWebServices();
+    await pluginHtlc.registerWebServices(expressApp);
+
+    log.info("Deploys HashTimeLock via .json file on initialize function");
+    const initRequest: InitializeRequest = {
+      connectorId,
+      keychainId,
+      constructorArgs: [],
+      web3SigningCredential,
+      gas: estimatedGas,
+    };
+    const deployOut = await pluginHtlc.initialize(initRequest);
+
+    expect(deployOut).toBeTruthy();
+    expect(deployOut.transactionReceipt).toBeTruthy();
+    expect(deployOut.transactionReceipt.contractAddress).toBeTruthy();
+
+    const hashTimeLockAddress = deployOut.transactionReceipt
+      .contractAddress as string;
+
+    log.info("Deploys TestToken via .json file on deployContract function");
+    const deployOutToken = await connector.deployContract({
+      contractName: TestTokenJSON.contractName,
+      contractAbi: TestTokenJSON.abi,
+      bytecode: TestTokenJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: ["100", "token", "2", "TKN"],
+      gas: estimatedGas,
+    });
+    expect(deployOutToken).toBeTruthy();
+    expect(deployOutToken.transactionReceipt).toBeTruthy();
+    expect(deployOutToken.transactionReceipt.contractAddress).toBeTruthy();
+
+    const tokenAddress = deployOutToken.transactionReceipt
+      .contractAddress as string;
+
+    log.info("Deploys DemoHelpers via .json file on deployContract function");
+    const deployOutDemo = await connector.deployContract({
+      contractName: DemoHelperJSON.contractName,
+      contractAbi: DemoHelperJSON.abi,
+      bytecode: DemoHelperJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: [],
+      gas: estimatedGas,
+    });
+
+    expect(deployOutDemo).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt.contractAddress).toBeTruthy();
+
+    log.info("Approve 10 Tokens to HashTimeLockAddress");
+    const { success } = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Send,
+      methodName: "approve",
+      params: [hashTimeLockAddress, "10"],
+      gas: estimatedGas,
+    });
+    expect(success).toBeTrue();
+
+    log.info("Get account balance");
+    const responseBalance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+    expect(responseBalance.callOutput).toEqual("100");
+
+    log.info("Get current timestamp");
+    const { callOutput } = await connector.invokeContract({
+      contractName: DemoHelperJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "getTimestamp",
+      params: [],
+    });
+    expect(callOutput).toBeTruthy();
+    let timestamp = 0;
+    timestamp = callOutput as number;
+    timestamp = +timestamp + +10;
+
+    log.info("Get HashTimeLock contract and account allowance");
+    const responseAllowance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "allowance",
+      params: [firstHighNetWorthAccount, hashTimeLockAddress],
+    });
+    expect(responseAllowance.callOutput).toEqual("10");
+
+    log.info("Create new contract for HTLC");
+    const request: NewContractRequest = {
+      contractAddress: hashTimeLockAddress,
+      inputAmount: 10,
+      outputAmount: 1,
+      expiration: timestamp,
+      hashLock,
+      tokenAddress,
+      receiver,
+      outputNetwork: "BTC",
+      outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
+      connectorId,
+      keychainId,
+      web3SigningCredential,
+      gas: estimatedGas,
+    };
+    const res = await api.newContractV1(request);
+    expect(res.status).toEqual(200);
+
+    log.info("Get HTLC Id from DemoHelper");
+    const responseTxId = await connector.invokeContract({
+      contractName: DemoHelperJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "getTxId",
+      params: [
+        firstHighNetWorthAccount,
+        receiver,
+        10,
+        hashLock,
+        timestamp,
+        tokenAddress,
+      ],
+    });
+    expect(responseTxId.callOutput).toBeTruthy();
+    const id = responseTxId.callOutput as string;
+
+    log.info("Refund HTLC when it is not possible yet");
+    try {
+      const refundRequest: RefundRequest = {
+        id,
+        web3SigningCredential,
+        connectorId,
+        keychainId,
+      };
+      const resRefund = await api.refundV1(refundRequest);
+      expect(resRefund.status).toEqual(400);
+    } catch (error) {
+      expect(error.response.status).toEqual(400);
+    }
+
+    log.info("Get balance of account");
+    const responseFinalBalance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+    expect(responseFinalBalance.callOutput).toEqual("90");
+  });
 });


### PR DESCRIPTION
test(htlc-eth-besu-erc20): migrate refund-endpoint test cases from Tape to Jest

Primary changes:
```
packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
```

Fixes: #3701

Signed-off-by: Udhayakumari 62878965+Udhayakumari@users.noreply.github.com

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.