### PR TITLE
feat(satp): Implement timeout and retry logic for SATP step messages

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/errors/satp-errors.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/errors/satp-errors.ts
@@ -101,3 +101,24 @@ export class RecoverMessageError extends SATPInternalError {
 }
 // TODO client-facing error logic, maps SATPInternalErrors to user friendly errors
 export class SATPError extends Error {}
+
+export class GatewayRetryOperationError extends SATPInternalError {
+  constructor(message: string, cause?: string | Error | null) {
+    super(message, cause ?? null, 500);
+  }
+}
+
+export class InvalidStageError extends SATPInternalError {
+  constructor(
+    fnTag: string,
+    stage: string,
+    sessionID: string,
+    cause?: string | Error | null,
+  ) {
+    super(
+      `${fnTag}, Invalid stage: ${stage} for session: ${sessionID}`,
+      cause ?? null,
+      400,
+    );
+  }
+}

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/services/gateway/satp-manager.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/services/gateway/satp-manager.ts
@@ -74,6 +74,8 @@ import {
   RecoverMessageError,
   RetrieveSATPMessageError,
   TransactError,
+  GatewayRetryOperationError,
+  InvalidStageError,
 } from "../../core/errors/satp-errors";
 import { getMessageTypeName } from "../../core/satp-utils";
 import { HealthCheckResponseStatusEnum } from "../../generated/gateway-client/typescript-axios";
@@ -110,6 +112,7 @@ export class SATPManager {
   public connectedDLTs: NetworkId[] = [];
   private supportedDLTs: LedgerType[] = [];
   private sessions: Map<string, SATPSession>;
+  private sessionConfig: any;
   // maps stage to client/service and service class
   private readonly satpServices: Map<
     string,
@@ -307,6 +310,16 @@ export class SATPManager {
   public getSATPHandler(type: SATPHandlerType): SATPHandler | undefined {
     return this.satpHandlers.get(type);
   }
+  private updateSessionConfig(sessionData: {
+    maxRetries: string;
+    maxTimeout: string;
+  }) {
+    this.sessionConfig = {
+      retries: parseInt(sessionData.maxRetries, 10),
+      timeoutMs: parseInt(sessionData.maxTimeout, 10),
+      delayMs: 500,
+    };
+  }
 
   public getOrCreateSession(
     sessionId?: string,
@@ -483,6 +496,51 @@ export class SATPManager {
     );
   }
 
+  /**
+   * Executes an asynchronous operation with retries and a timeout.
+   * - The function attempts to perform the 'operation' up to 'retries' times until it succeeds.
+   * - Each attempt must complete within 'timeoutMs', or it is considered failed.
+   * - Waits 'delayMs' milliseconds between retries to avoid immediate retries.
+   * @param operation The asynchronous operation to execute, returning a Promise.
+   * @param error The error to throw if the operation fails after all retries/timeout.
+   * @returns A Promise resolved with the operation's result or rejected after all retries fail.
+   * @throws Error if the operation fails after all retries or if the operation times out.
+   */
+  private async executeOperationWithRetriesAndTimeout<T>(
+    operation: () => Promise<T>,
+    error: Error,
+  ): Promise<T> {
+    let { retries, timeoutMs } = this.sessionConfig;
+    const { delayMs } = this.sessionConfig;
+    retries = isNaN(retries) ? 3 : retries;
+    timeoutMs = isNaN(timeoutMs) ? 5000 : timeoutMs;
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      try {
+        this.logger.debug(`Attempt ${attempt}: Starting operation`);
+        return await Promise.race([
+          operation(),
+          new Promise<T>((_, reject) =>
+            setTimeout(
+              () => () =>
+                reject(
+                  new GatewayRetryOperationError(
+                    `Operation ${operation} timed out`,
+                  ),
+                ),
+              timeoutMs,
+            ),
+          ),
+        ]);
+      } catch (err) {
+        this.logger.error(`Attempt ${attempt} failed: ${err.message}`);
+        if (attempt < retries) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+      }
+    }
+    throw error;
+  }
+
   public async transfer(
     session: SATPSession,
     stage?: MessageType,
@@ -526,6 +584,9 @@ export class SATPManager {
       }
 
       const sessionData: SessionData = clientSessionData;
+
+      // Updating retry and timeout settings for the session
+      this.updateSessionConfig(sessionData);
 
       sessionData.receiverGatewayOwnerId = channel.toGatewayID;
 
@@ -585,16 +646,17 @@ export class SATPManager {
         case undefined:
         case MessageType.NEW_SESSION_REQUEST:
           this.logger.debug(`${fnTag}, Initiating Stage 0`);
-          newSessionRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE0) as Stage0SATPHandler
-          ).NewSessionRequest(session.getSessionId());
-
-          if (!newSessionRequest) {
-            throw new CreateSATPRequestError(
+          this.logger.debug("CREATING A NEW REQUEST");
+          newSessionRequest = await this.executeOperationWithRetriesAndTimeout(
+            async () =>
+              await (
+                this.getSATPHandler(SATPHandlerType.STAGE0) as Stage0SATPHandler
+              ).NewSessionRequest(session.getSessionId()),
+            new CreateSATPRequestError(
               fnTag,
               getMessageTypeName(MessageType.NEW_SESSION_REQUEST),
-            );
-          }
+            ),
+          );
 
         case MessageType.NEW_SESSION_RESPONSE:
           if (!newSessionRequest) {
@@ -613,21 +675,18 @@ export class SATPManager {
               );
             }
           }
-
-          newSessionResponse =
-            await clientSatpStage0.newSession(newSessionRequest);
-
+          newSessionResponse = await this.executeOperationWithRetriesAndTimeout(
+            async () => {
+              return await clientSatpStage0.newSession(newSessionRequest!);
+            },
+            new RetrieveSATPMessageError(
+              fnTag,
+              getMessageTypeName(MessageType.NEW_SESSION_RESPONSE),
+            ),
+          );
           this.logger.debug(
             `${fnTag}, newSessionResponse: ${safeStableStringify(newSessionResponse)}`,
           );
-
-          if (!newSessionResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.NEW_SESSION_RESPONSE),
-            );
-          }
-
         case MessageType.PRE_SATP_TRANSFER_REQUEST:
           if (!newSessionResponse) {
             this.logger.debug(
@@ -645,17 +704,22 @@ export class SATPManager {
               );
             }
           }
-
-          preSATPTransferRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE0) as Stage0SATPHandler
-          ).PreSATPTransferRequest(newSessionResponse, session.getSessionId());
-
-          if (!preSATPTransferRequest) {
-            throw new CreateSATPRequestError(
-              fnTag,
-              getMessageTypeName(MessageType.PRE_SATP_TRANSFER_REQUEST),
+          preSATPTransferRequest =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await (
+                  this.getSATPHandler(
+                    SATPHandlerType.STAGE0,
+                  ) as Stage0SATPHandler
+                ).PreSATPTransferRequest(
+                  newSessionResponse!,
+                  session.getSessionId(),
+                ),
+              new CreateSATPRequestError(
+                fnTag,
+                getMessageTypeName(MessageType.PRE_SATP_TRANSFER_REQUEST),
+              ),
             );
-          }
 
         case MessageType.PRE_SATP_TRANSFER_RESPONSE:
           if (!preSATPTransferRequest) {
@@ -674,21 +738,21 @@ export class SATPManager {
               );
             }
           }
-
-          preSATPTransferResponse = await clientSatpStage0.preSATPTransfer(
-            preSATPTransferRequest,
-          );
-
+          preSATPTransferResponse =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () => {
+                return await clientSatpStage0.preSATPTransfer(
+                  preSATPTransferRequest!,
+                );
+              },
+              new RetrieveSATPMessageError(
+                fnTag,
+                getMessageTypeName(MessageType.PRE_SATP_TRANSFER_RESPONSE),
+              ),
+            );
           this.logger.debug(
             `${fnTag}, preSATPTransferResponse: ${safeStableStringify(preSATPTransferResponse)}`,
           );
-
-          if (!preSATPTransferResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.PRE_SATP_TRANSFER_RESPONSE),
-            );
-          }
 
         case MessageType.INIT_PROPOSAL:
           if (!preSATPTransferResponse) {
@@ -709,20 +773,22 @@ export class SATPManager {
           }
 
           this.logger.debug(`${fnTag}, Initiating Stage 1`);
-
-          transferProposalRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE1) as Stage1SATPHandler
-          ).TransferProposalRequest(
-            session.getSessionId(),
-            preSATPTransferResponse,
-          );
-
-          if (!transferProposalRequest) {
-            throw new CreateSATPRequestError(
-              fnTag,
-              getMessageTypeName(MessageType.INIT_PROPOSAL),
+          transferProposalRequest =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await (
+                  this.getSATPHandler(
+                    SATPHandlerType.STAGE1,
+                  ) as Stage1SATPHandler
+                ).TransferProposalRequest(
+                  session.getSessionId(),
+                  preSATPTransferResponse!,
+                ),
+              new CreateSATPRequestError(
+                fnTag,
+                getMessageTypeName(MessageType.INIT_PROPOSAL),
+              ),
             );
-          }
         case MessageType.INIT_RECEIPT:
         case MessageType.INIT_REJECT:
           if (!transferProposalRequest) {
@@ -734,28 +800,29 @@ export class SATPManager {
               MessageType.INIT_PROPOSAL,
             ) as TransferProposalRequest;
 
-            if (!transferProposalRequest) {
-              throw new RecoverMessageError(
-                fnTag,
-                getMessageTypeName(MessageType.INIT_PROPOSAL),
+                new RecoverMessageError(
+                  fnTag,
+                  getMessageTypeName(MessageType.INIT_PROPOSAL),
+                ),
               );
-            }
           }
 
-          transferProposalResponse = await clientSatpStage1.transferProposal(
-            transferProposalRequest,
-          );
+          transferProposalResponse =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await clientSatpStage1.transferProposal(
+                  transferProposalRequest!,
+                ),
 
+              new RetrieveSATPMessageError(
+                fnTag,
+                getMessageTypeName(MessageType.INIT_RECEIPT),
+              ),
+            );
           this.logger.debug(
             `${fnTag}, transferProposalResponse: ${safeStableStringify(transferProposalResponse)}`,
           );
 
-          if (!transferProposalResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.INIT_RECEIPT),
-            );
-          }
         case MessageType.TRANSFER_COMMENCE_REQUEST:
           if (!transferProposalResponse) {
             this.logger.debug(
@@ -774,16 +841,21 @@ export class SATPManager {
             }
           }
 
-          transferCommenceRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE1) as Stage1SATPHandler
-          ).TransferCommenceRequest(transferProposalResponse);
+          transferCommenceRequest =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await (
+                  this.getSATPHandler(
+                    SATPHandlerType.STAGE1,
+                  ) as Stage1SATPHandler
+                ).TransferCommenceRequest(transferProposalResponse!),
 
-          if (!transferCommenceRequest) {
-            throw new CreateSATPRequestError(
-              fnTag,
-              getMessageTypeName(MessageType.TRANSFER_COMMENCE_REQUEST),
+              new CreateSATPRequestError(
+                fnTag,
+                getMessageTypeName(MessageType.TRANSFER_COMMENCE_REQUEST),
+              ),
             );
-          }
+
         case MessageType.TRANSFER_COMMENCE_RESPONSE:
           if (!transferCommenceRequest) {
             this.logger.debug(
@@ -802,20 +874,22 @@ export class SATPManager {
             }
           }
 
-          transferCommenceResponse = await clientSatpStage1.transferCommence(
-            transferCommenceRequest,
-          );
+          transferCommenceResponse =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await clientSatpStage1.transferCommence(
+                  transferCommenceRequest!,
+                ),
 
+              new RetrieveSATPMessageError(
+                fnTag,
+                getMessageTypeName(MessageType.TRANSFER_COMMENCE_RESPONSE),
+              ),
+            );
           this.logger.debug(
             `${fnTag}, transferCommenceResponse: ${safeStableStringify(transferCommenceResponse)}`,
           );
 
-          if (!transferCommenceResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.TRANSFER_COMMENCE_RESPONSE),
-            );
-          }
         case MessageType.LOCK_ASSERT:
           if (!transferCommenceResponse) {
             this.logger.debug(
@@ -836,21 +910,27 @@ export class SATPManager {
 
           this.logger.debug(`${fnTag}, Initiating Stage 2`);
 
-          lockAssertionRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE2) as Stage2SATPHandler
-          ).LockAssertionRequest(transferCommenceResponse);
+          lockAssertionRequest =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await (
+                  this.getSATPHandler(
+                    SATPHandlerType.STAGE2,
+                  ) as Stage2SATPHandler
+                ).LockAssertionRequest(transferCommenceResponse!),
 
-          if (!lockAssertionRequest) {
-            throw new CreateSATPRequestError(
-              fnTag,
-              getMessageTypeName(MessageType.LOCK_ASSERT),
+              new CreateSATPRequestError(
+                fnTag,
+                getMessageTypeName(MessageType.LOCK_ASSERT),
+              ),
             );
-          }
+
         case MessageType.ASSERTION_RECEIPT:
           if (!lockAssertionRequest) {
             this.logger.debug(
               `${fnTag}, Recovering from Stage 2, LockAssertionRequest`,
             );
+
             lockAssertionRequest = getMessageInSessionData(
               sessionData,
               MessageType.LOCK_ASSERT,
@@ -865,23 +945,24 @@ export class SATPManager {
           }
 
           lockAssertionResponse =
-            await clientSatpStage2.lockAssertion(lockAssertionRequest);
-
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await clientSatpStage2.lockAssertion(lockAssertionRequest!),
+              new RetrieveSATPMessageError(
+                fnTag,
+                getMessageTypeName(MessageType.ASSERTION_RECEIPT),
+              ),
+            );
           this.logger.debug(
             `${fnTag}, lockAssertionResponse: ${safeStableStringify(lockAssertionResponse)}`,
           );
 
-          if (!lockAssertionResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.ASSERTION_RECEIPT),
-            );
-          }
         case MessageType.COMMIT_PREPARE:
           if (!lockAssertionResponse) {
             this.logger.debug(
               `${fnTag}, Recovering from Stage 2, LockAssertionResponse`,
             );
+
             lockAssertionResponse = getMessageInSessionData(
               sessionData,
               MessageType.ASSERTION_RECEIPT,
@@ -897,21 +978,27 @@ export class SATPManager {
 
           this.logger.debug(`${fnTag}, Initiating Stage 3`);
 
-          commitPreparationRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE3) as Stage3SATPHandler
-          ).CommitPreparationRequest(lockAssertionResponse);
+          commitPreparationRequest =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await (
+                  this.getSATPHandler(
+                    SATPHandlerType.STAGE3,
+                  ) as Stage3SATPHandler
+                ).CommitPreparationRequest(lockAssertionResponse!),
 
-          if (!commitPreparationRequest) {
-            throw new CreateSATPRequestError(
-              fnTag,
-              getMessageTypeName(MessageType.COMMIT_PREPARE),
+              new CreateSATPRequestError(
+                fnTag,
+                getMessageTypeName(MessageType.COMMIT_PREPARE),
+              ),
             );
-          }
+
         case MessageType.COMMIT_READY:
           if (!commitPreparationRequest) {
             this.logger.debug(
               `${fnTag}, Recovering from Stage 3, CommitPreparationRequest`,
             );
+
             commitPreparationRequest = getMessageInSessionData(
               sessionData,
               MessageType.COMMIT_PREPARE,
@@ -925,25 +1012,28 @@ export class SATPManager {
             }
           }
 
-          commitReadyResponse = await clientSatpStage3.commitPreparation(
-            commitPreparationRequest,
-          );
+          commitReadyResponse =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await clientSatpStage3.commitPreparation(
+                  commitPreparationRequest!,
+                ),
 
+              new RetrieveSATPMessageError(
+                fnTag,
+                getMessageTypeName(MessageType.COMMIT_READY),
+              ),
+            );
           this.logger.debug(
             `${fnTag}, commitReadyResponse: ${safeStableStringify(commitReadyResponse)}`,
           );
 
-          if (!commitReadyResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.COMMIT_READY),
-            );
-          }
         case MessageType.COMMIT_FINAL:
           if (!commitReadyResponse) {
             this.logger.debug(
               `${fnTag}, Recovering from Stage 3, CommitReadyResponse`,
             );
+
             commitReadyResponse = getMessageInSessionData(
               sessionData,
               MessageType.COMMIT_READY,
@@ -957,22 +1047,27 @@ export class SATPManager {
             }
           }
 
-          commitFinalAssertionRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE3) as Stage3SATPHandler
-          ).CommitFinalAssertionRequest(commitReadyResponse);
+          commitFinalAssertionRequest =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await (
+                  this.getSATPHandler(
+                    SATPHandlerType.STAGE3,
+                  ) as Stage3SATPHandler
+                ).CommitFinalAssertionRequest(commitReadyResponse!),
 
-          if (!commitFinalAssertionRequest) {
-            throw new CreateSATPRequestError(
-              fnTag,
-              getMessageTypeName(MessageType.COMMIT_FINAL),
+              new CreateSATPRequestError(
+                fnTag,
+                getMessageTypeName(MessageType.COMMIT_FINAL),
+              ),
             );
-          }
 
         case MessageType.ACK_COMMIT_FINAL:
           if (!commitFinalAssertionRequest) {
             this.logger.debug(
               `${fnTag}, Recovering from Stage 3, CommitFinalAssertionRequest`,
             );
+
             commitFinalAssertionRequest = getMessageInSessionData(
               sessionData,
               MessageType.COMMIT_FINAL,
@@ -987,25 +1082,27 @@ export class SATPManager {
           }
 
           commitFinalAcknowledgementReceiptResponse =
-            await clientSatpStage3.commitFinalAssertion(
-              commitFinalAssertionRequest,
-            );
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await clientSatpStage3.commitFinalAssertion(
+                  commitFinalAssertionRequest!,
+                ),
 
+              new RetrieveSATPMessageError(
+                fnTag,
+                getMessageTypeName(MessageType.ACK_COMMIT_FINAL),
+              ),
+            );
           this.logger.debug(
             `${fnTag}, commitFinalAcknowledgementReceiptResponse: ${safeStableStringify(commitFinalAcknowledgementReceiptResponse)}`,
           );
 
-          if (!commitFinalAcknowledgementReceiptResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.ACK_COMMIT_FINAL),
-            );
-          }
         case MessageType.COMMIT_TRANSFER_COMPLETE:
           if (!commitFinalAcknowledgementReceiptResponse) {
             this.logger.debug(
               `${fnTag}, Recovering from Stage 3, CommitFinalAcknowledgementReceiptResponse`,
             );
+
             commitFinalAcknowledgementReceiptResponse = getMessageInSessionData(
               sessionData,
               MessageType.ACK_COMMIT_FINAL,
@@ -1019,16 +1116,23 @@ export class SATPManager {
             }
           }
 
-          transferCompleteRequest = await (
-            this.getSATPHandler(SATPHandlerType.STAGE3) as Stage3SATPHandler
-          ).TransferCompleteRequest(commitFinalAcknowledgementReceiptResponse);
+          transferCompleteRequest =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await (
+                  this.getSATPHandler(
+                    SATPHandlerType.STAGE3,
+                  ) as Stage3SATPHandler
+                ).TransferCompleteRequest(
+                  commitFinalAcknowledgementReceiptResponse!,
+                ),
 
-          if (!transferCompleteRequest) {
-            throw new CreateSATPRequestError(
-              fnTag,
-              getMessageTypeName(MessageType.COMMIT_TRANSFER_COMPLETE),
+              new CreateSATPRequestError(
+                fnTag,
+                getMessageTypeName(MessageType.COMMIT_TRANSFER_COMPLETE),
+              ),
             );
-          }
+
         case MessageType.COMMIT_TRANSFER_COMPLETE_RESPONSE:
           if (!transferCompleteRequest) {
             this.logger.debug(
@@ -1047,27 +1151,34 @@ export class SATPManager {
             }
           }
 
-          transferCompleteResponse = await clientSatpStage3.transferComplete(
-            transferCompleteRequest,
-          );
+          transferCompleteResponse =
+            await this.executeOperationWithRetriesAndTimeout(
+              async () =>
+                await clientSatpStage3.transferComplete(
+                  transferCompleteRequest!,
+                ),
 
+              new RetrieveSATPMessageError(
+                fnTag,
+                getMessageTypeName(
+                  MessageType.COMMIT_TRANSFER_COMPLETE_RESPONSE,
+                ),
+              ),
+            );
           this.logger.debug(
             `${fnTag}, transferCompleteResponse: ${safeStableStringify(transferCompleteResponse)}`,
           );
-
-          if (!transferCompleteResponse) {
-            throw new RetrieveSATPMessageError(
-              fnTag,
-              getMessageTypeName(MessageType.COMMIT_TRANSFER_COMPLETE_RESPONSE),
-            );
-          }
 
           (
             this.getSATPHandler(SATPHandlerType.STAGE3) as Stage3SATPHandler
           ).CheckTransferCompleteResponse(transferCompleteResponse);
           break;
         default:
-          throw new Error("Invalid stage");
+          throw new InvalidStageError(
+            fnTag,
+            stage.toString(),
+            session.getSessionId(),
+          );
       }
       this.logger.debug(
         `${fnTag}, Transfer Completed for session: ${session.getSessionId()}`,


### PR DESCRIPTION
Introduces a new utility function, executeOperationWithRetriesAndTimeout, which encapsulates retry and timeout logic for SATP step message processing. This update aims to enhance reliability by handling transient failures and timeouts effectively.

Additionally, two new error types are introduced in satp-errors.ts:
1. GatewayRetryOperationError: Thrown when retries are exhausted without success.
2. InvalidStageError: Thrown when an invalid stage is encountered during the SATP process.

Resolves #3744.

**Pull Request Requirements**
- [ X] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [X ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ X] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [X ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ X] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.