### PR TITLE
fix(satp-hermes): shutdown of SATP gateway should assure there are no pending transfers before shutting down

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/gateway-errors.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/api1/gateway-errors.ts
@@ -1,0 +1,28 @@
+import { asError } from "@hyperledger/cactus-common";
+import { RuntimeError } from "run-time-error-cjs";
+import { Error as GatewayErrorType } from "../generated/proto/cacti/satp/v02/common/message_pb";
+export class GatewayError extends RuntimeError {
+  protected errorType = GatewayErrorType.UNSPECIFIED;
+  constructor(
+    public message: string,
+    public cause: string | Error | null,
+    // TODO internal error codes
+    public code: number = 500,
+    public traceID?: string,
+    public trace?: string,
+  ) {
+    super(message, asError(cause));
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype); // make sure prototype chain is set to error
+  }
+
+  public getGatewayErrorType(): GatewayErrorType {
+    return this.errorType;
+  }
+}
+
+export class GatewayShuttingDownError extends GatewayError {
+  constructor(tag: string, cause?: string | Error | null) {
+    super(`${tag}, shutdown initiated not receiving new requests`, cause ?? null, 500);
+  }
+}

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/errors/satp-errors.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/errors/satp-errors.ts
@@ -99,5 +99,11 @@ export class RecoverMessageError extends SATPInternalError {
     super(`${tag}, failed to recover message: ${message}`, cause ?? null, 500);
   }
 }
+
+export class BLODispatcherErraneousError extends SATPInternalError {
+  constructor(tag: string, cause?: string | Error | null) {
+    super(`${tag}, failed because BLODispatcher is erroneous`, cause ?? null, 500);
+  }
+}
 // TODO client-facing error logic, maps SATPInternalErrors to user friendly errors
 export class SATPError extends Error {}

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/services/gateway/satp-manager.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/services/gateway/satp-manager.ts
@@ -37,6 +37,7 @@ import { Stage2SATPHandler } from "../../core/stage-handlers/stage2-handler";
 import { Stage3SATPHandler } from "../../core/stage-handlers/stage3-handler";
 import { SATPCrossChainManager } from "../../cross-chain-mechanisms/satp-cc-manager";
 import { GatewayOrchestrator } from "./gateway-orchestrator";
+import { State } from "../../generated/proto/cacti/satp/v02/common/session_pb";
 import type { SessionData } from "../../generated/proto/cacti/satp/v02/common/session_pb";
 import type { SatpStage0Service } from "../../generated/proto/cacti/satp/v02/service/stage_0_pb";
 import type { SatpStage1Service } from "../../generated/proto/cacti/satp/v02/service/stage_1_pb";
@@ -308,6 +309,21 @@ export class SATPManager {
 
   public getSATPHandler(type: SATPHandlerType): SATPHandler | undefined {
     return this.satpHandlers.get(type);
+  }
+
+  /*
+    * Function checks if all the sessions are in the completed state
+    * @returns boolean
+  */
+  public getSATPSessionState(): boolean {
+    const fnTag = `${SATPManager.CLASS_NAME}#getSATPSessionStatus()`;
+    this.logger.info(`${fnTag}, Getting SATP Session Status...`);
+    for (let value of this.sessions.values()) {
+      if (value.getSessionState() !== State.COMPLETED) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public getOrCreateSession(

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/shutdown-state.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/shutdown-state.test.ts
@@ -1,0 +1,215 @@
+import "jest-extended";
+import {
+  Containers,
+  pruneDockerAllIfGithubAction,
+} from "@hyperledger/cactus-test-tooling";
+import {
+  LogLevelDesc,
+  LoggerProvider,
+} from "@hyperledger/cactus-common";
+import {
+  SATPGateway,
+  SATPGatewayConfig,
+} from "../../../main/typescript/plugin-satp-hermes-gateway";
+import { PluginFactorySATPGateway } from "../../../main/typescript/factory/plugin-factory-gateway-orchestrator";
+import { 
+  IPluginFactoryOptions,
+  LedgerType,
+  PluginImportType,
+} from "@hyperledger/cactus-core-api";
+import {
+  SATP_ARCHITECTURE_VERSION,
+  SATP_CORE_VERSION,
+  SATP_CRASH_VERSION,
+} from "../../../main/typescript/core/constants";
+import {
+  knexClientConnection,
+  knexSourceRemoteConnection,
+} from "../knex.config";
+import { SATPSession } from "../../../main/typescript/core/satp-session";
+import { 
+  TransactRequest,
+  TransactRequestSourceAsset
+ } from "../../../main/typescript";
+
+const logLevel: LogLevelDesc = "DEBUG";
+const logger = LoggerProvider.getOrCreate({
+  level: logLevel,
+  label: "satp-gateway-orchestrator-init-test",
+});
+const factoryOptions: IPluginFactoryOptions = {
+  pluginImportType: PluginImportType.Local,
+};
+const factory = new PluginFactorySATPGateway(factoryOptions);
+
+let mockSession: SATPSession;
+const sessionIDs: string[] = [];
+
+beforeAll(async () => {
+  pruneDockerAllIfGithubAction({ logLevel })
+    .then(() => {
+      logger.info("Pruning throw OK");
+    })
+    .catch(async () => {
+      await Containers.logDiagnostics({ logLevel });
+      fail("Pruning didn't throw OK");
+    });
+  mockSession = new SATPSession({
+      contextID: "MOCK_CONTEXT_ID",
+      server: false,
+      client: true,
+    });
+  
+  sessionIDs.push(mockSession.getSessionId());
+});
+
+describe("Shutdown Verify State Tests", () => {
+  test("Gateway waits to verify the sessions state before shutdown", async () => {
+    const options: SATPGatewayConfig = {
+      gid: {
+        id: "mockID",
+        name: "CustomGateway",
+        version: [
+          {
+            Core: SATP_CORE_VERSION,
+            Architecture: SATP_ARCHITECTURE_VERSION,
+            Crash: SATP_CRASH_VERSION,
+          },
+        ],
+        connectedDLTs: [],
+        proofID: "mockProofID10",
+        gatewayServerPort: 3014,
+        gatewayClientPort: 3015,
+        address: "https://localhost",
+      },
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
+    };
+  
+    const gateway = await factory.create(options);
+    expect(gateway).toBeInstanceOf(SATPGateway);
+  
+    const verifySessionsStateSpy = jest.spyOn(gateway as any, "verifySessionsState");
+  
+    const shutdownBLOServerSpy = jest.spyOn(gateway as any, "shutdownBLOServer");
+
+    await gateway.startup();
+    await gateway.shutdown();
+ 
+    expect(verifySessionsStateSpy).toHaveBeenCalled();
+
+    expect(shutdownBLOServerSpy).toHaveBeenCalled();
+
+    verifySessionsStateSpy.mockRestore();
+    shutdownBLOServerSpy.mockRestore();
+  });
+
+  test("Gateway waits for pending sessions to complete before shutdown", async () => {
+    const options: SATPGatewayConfig = {
+      gid: {
+        id: "mockID",
+        name: "CustomGateway",
+        version: [
+          {
+            Core: SATP_CORE_VERSION,
+            Architecture: SATP_ARCHITECTURE_VERSION,
+            Crash: SATP_CRASH_VERSION,
+          },
+        ],
+        connectedDLTs: [],
+        proofID: "mockProofID10",
+        gatewayServerPort: 3014,
+        gatewayClientPort: 3015,
+        address: "https://localhost",
+      },
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
+    };
+  
+    const gateway = await factory.create(options);
+    expect(gateway).toBeInstanceOf(SATPGateway);
+  
+    const satpManager = (gateway as any).BLODispatcher.manager;
+
+    let sessionState = false;
+    satpManager.getSessions().set(mockSession.getSessionId(), mockSession);
+
+    await gateway.startup();
+
+    const shutdownPromise = gateway.shutdown();
+
+    const initialSessionState = await satpManager.getSATPSessionState();
+    expect(initialSessionState).toBe(false);
+  
+    const getSATPSessionStateSpy = jest
+      .spyOn(satpManager, "getSATPSessionState")
+      .mockImplementation(async () => {
+        if (!sessionState) {
+          await new Promise((resolve) => setTimeout(resolve, 20000)); 
+          sessionState = true;
+        }
+        return sessionState;
+      });
+    
+    await shutdownPromise;
+
+    const finalSessionState = await satpManager.getSATPSessionState();
+    expect(finalSessionState).toBe(true); 
+
+    getSATPSessionStateSpy.mockRestore();
+    
+  });
+
+  test("Gateway does not allow new transactions after shutdown is initiated", async () => {
+    const options: SATPGatewayConfig = {
+      gid: {
+        id: "mockID",
+        name: "CustomGateway",
+        version: [
+          {
+            Core: SATP_CORE_VERSION,
+            Architecture: SATP_ARCHITECTURE_VERSION,
+            Crash: SATP_CRASH_VERSION,
+          },
+        ],
+        connectedDLTs: [],
+        proofID: "mockProofID10",
+        gatewayServerPort: 3014,
+        gatewayClientPort: 3015,
+        address: "https://localhost",
+      },
+      knexLocalConfig: knexClientConnection,
+      knexRemoteConfig: knexSourceRemoteConnection,
+    };
+  
+    const gateway = await factory.create(options);
+    expect(gateway).toBeInstanceOf(SATPGateway);
+  
+    await gateway.startup();
+  
+    const shutdownPromise = gateway.shutdown();
+
+    const transactRequestSourceAsset: TransactRequestSourceAsset = {
+      owner: "mockOwner",
+      ontology: "mockOntology",
+      contractName: "mockContractName",
+    };
+  
+    const transactRequest: TransactRequest = {
+      contextID: "mockContextID",
+      fromDLTNetworkID: "mockFromDLTNetworkID",
+      toDLTNetworkID: "mockToDLTNetworkID",
+      fromAmount: "100",
+      toAmount: "100",
+      beneficiaryPubkey: "mockBeneficiaryPubkey",
+      originatorPubkey: "mockOriginatorPubkey",
+      sourceAsset: transactRequestSourceAsset,
+      receiverAsset: transactRequestSourceAsset,
+    };
+  
+    await expect(gateway.BLODispatcherInstance?.Transact(transactRequest)).rejects.toThrow("BLODispatcher#transact(), shutdown initiated not receiving new requests");
+  
+    await shutdownPromise;
+  });
+});
+


### PR DESCRIPTION
Introduces a new function, `verifySessionState`, which upon shutdown verifies if all sessions are concluded. Also a flag was created to prevent new transactions to occur when shutdown was already called.

Additionally, a new type of error is introduced `gateway-error` .

Resolves #3756.
**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.