### PR TITLE
feat(common): add BigInt JSON replacer (number -> string)

### DIFF
--- a/packages/cactus-common/src/main/typescript/public-api.ts
+++ b/packages/cactus-common/src/main/typescript/public-api.ts
@@ -50,3 +50,5 @@ export {
 export { isGrpcStatusObjectWithCode } from "./grpc/is-grpc-status-object-with-code";
 
 export { HttpHeader } from "./http/http-header";
+
+export { bigIntToHexReplacer } from "./serde/json/big-int";

--- a/packages/cactus-common/src/main/typescript/serde/json/big-int.ts
+++ b/packages/cactus-common/src/main/typescript/serde/json/big-int.ts
@@ -1,0 +1,11 @@
+/**
+ * A JSON replacer that converts BigInt values to strings
+ *
+ * @returns `"999999999999999999"` for an  input of `BigInt(999999999999999999n)`
+ */
+export function bigIntToHexReplacer(_key: string, value: any) {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+}


### PR DESCRIPTION
This can be used by code on the back-end to be able to safely send
BigInt values through the  various transports (HTTP, gRPC, CRPC, etc.)

By default JSON.stringify will convert BigInt values to numbers which
can cause data loss if the number is too large. By using this replacer
function, we can ensure that BigInt values are always sent as strings.

It adds overhead on the client side to have to manually parse the BigInt
values, but it is a necessary trade-off for preserving data integrity.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.