### PR TITLE
feat(cmd-api-server): configurable OpenAPI HTTP request validation

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/config/config-service.ts
@@ -27,6 +27,7 @@ convict.addFormat(FORMAT_PLUGIN_ARRAY);
 convict.addFormat(ipaddress);
 
 export interface ICactusApiServerOptions {
+  openApiValidationOffPkgs: string[];
   crpcPort: number;
   crpcHost: string;
   pluginManagerOptionsJson: string;
@@ -92,6 +93,23 @@ export class ConfigService {
 
   private static getConfigSchema(): Schema<ICactusApiServerOptions> {
     return {
+      openApiValidationOffPkgs: {
+        type: Array,
+        arg: "open-api-validation-off-pkgs",
+        env: "OPEN_API_VALIDATION_OFF_PKGS",
+        default: [],
+        doc:
+          "" +
+          "The list of package names for which OpenAPI validation should be disabled." +
+          "This is useful when dealing with plugins that have incorrect or incomplete" +
+          "OpenAPI specifications or when there is a bug in the OpenAPI validator" +
+          "middleware that cause it to have false negatives during validation." +
+          "This option is optional and defaults to an empty array which means that" +
+          "all of the plugins will have the OpenAPI request validation enabled by default." +
+          "   @example Setting this configuration parameter to" +
+          '["@hyperledger/cactus-plugin-ledger-connector-ethereum"]' +
+          "will disable OpenAPI validation for the Ethereum connector plugin.",
+      },
       crpcHost: {
         doc: "The host to bind the CRPC fastify instance to. Secure default is: 127.0.0.1. Use 0.0.0.0 to bind for any host.",
         format: "ipaddress",
@@ -570,6 +588,7 @@ export class ConfigService {
     };
 
     return {
+      openApiValidationOffPkgs: [],
       crpcHost: (schema.crpcHost as SchemaObj).default,
       crpcPort: (schema.crpcPort as SchemaObj).default,
       pluginManagerOptionsJson: "{}",

--- a/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-openapi-validation-off-pkgs.test.ts
+++ b/packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-openapi-validation-off-pkgs.test.ts
@@ -1,0 +1,81 @@
+import { randomUUID as uuidv4 } from "node:crypto";
+import path from "node:path";
+
+import "jest-extended";
+
+import { LogLevelDesc } from "@hyperledger/cactus-common";
+
+import {
+  PluginImportType,
+  PluginImportAction,
+} from "@hyperledger/cactus-core-api";
+
+import {
+  ApiServer,
+  AuthorizationProtocol,
+  ConfigService,
+} from "@hyperledger/cactus-cmd-api-server";
+
+const logLevel: LogLevelDesc = "TRACE";
+const testcase = "can instal plugins at runtime based on imports";
+
+describe(testcase, () => {
+  let apiServer: ApiServer;
+
+  beforeAll(async () => {
+    const pluginsPath = path.join(
+      __dirname,
+      "../../../../../../", // walk back up to the project root
+      ".tmp/test/test-cmd-api-server/plugin-import-with-npm-install_test/", // the dir path from the root
+      uuidv4(), // then a random directory to ensure proper isolation
+    );
+    const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
+
+    const configService = new ConfigService();
+
+    const apiSrvOpts = await configService.newExampleConfig();
+    apiSrvOpts.pluginManagerOptionsJson = pluginManagerOptionsJson;
+    apiSrvOpts.openApiValidationOffPkgs = [
+      "@hyperledger/cactus-plugin-keychain-memory",
+    ];
+    apiSrvOpts.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiSrvOpts.configFile = "";
+    apiSrvOpts.apiCorsDomainCsv = "*";
+    apiSrvOpts.apiPort = 0;
+    apiSrvOpts.cockpitPort = 0;
+    apiSrvOpts.grpcPort = 0;
+    apiSrvOpts.crpcPort = 0;
+    apiSrvOpts.apiTlsEnabled = false;
+    apiSrvOpts.plugins = [
+      {
+        packageName: "@hyperledger/cactus-plugin-keychain-memory",
+        type: PluginImportType.Local,
+        action: PluginImportAction.Install,
+        options: {
+          instanceId: uuidv4(),
+          keychainId: uuidv4(),
+          logLevel,
+        },
+      },
+    ];
+    const config = await configService.newExampleConfigConvict(apiSrvOpts);
+
+    apiServer = new ApiServer({
+      config: config.getProperties(),
+    });
+  });
+  afterAll(() => apiServer.shutdown());
+
+  test(testcase, async () => {
+    const openApiValidationOffPlugins =
+      await apiServer.getOpenApiValidationOffPlugins();
+    expect(openApiValidationOffPlugins.length).toBe(0);
+    const startResponse = apiServer.start();
+    await expect(startResponse).resolves.toBeTruthy();
+    expect(openApiValidationOffPlugins.length).toBe(1);
+    const [plugin] = openApiValidationOffPlugins;
+    expect(plugin.getPackageName()).toBe(
+      "@hyperledger/cactus-plugin-keychain-memory",
+    );
+  });
+});


### PR DESCRIPTION
Added the new `openApiValidationOffPkgs` configuration parameter to the API
server. It accepts a list of package names for which OpenAPI validation should be disabled.

This is useful when dealing with plugins that have incorrect or incomplete
OpenAPI specifications or when there is a bug in the OpenAPI validator
middleware that cause it to have false negatives during validation.

This configuration parameter is optional and defaults to an empty array which means that
all of the plugins will have the OpenAPI request validation enabled by default.
As am example, setting this configuration parameter to
`["@hyperledger/cactus-plugin-ledger-connector-ethereum"]`
will disable OpenAPI validation for the Ethereum connector plugin

Fixes #3831

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.