### PR TITLE
test(fabric-connector): connector-fabric-baseline test is failing

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/asset-transfer-private-data/chaincode-go/go.mod
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/asset-transfer-private-data/chaincode-go/go.mod
@@ -1,6 +1,8 @@
 module github.com/hyperledger/fabric-samples/asset-transfer-private-data/chaincode-go
 
-go 1.18
+go 1.23.0
+
+toolchain go1.23.2
 
 require (
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200511190512-bcfeb58dd83a

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/asset-transfer-private-data/chaincode-go/go.sum
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/asset-transfer-private-data/chaincode-go/go.sum
@@ -50,6 +50,7 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20200424173110-d7076418f212/go.mod h1:N7H3sA7Tx4k/YzFq7U0EPdqJtqvM4Kild0JoCc7C0Dc=
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20200511190512-bcfeb58dd83a h1:KoFw2HnRfW+EItMP0zvUUl1FGzDb/7O0ov7uXZffQok=

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
@@ -53,8 +53,10 @@ const log: Logger = LoggerProvider.getOrCreate({
   level: logLevel,
 });
 
-// Skipping due to test being flaky, see https://github.com/hyperledger/cactus/issues/1471
-describe("Deploy CC from Javascript Source Test", () => {
+// Skipping due to test being flaky.
+// @see https://github.com/hyperledger-cacti/cacti/issues/3842
+// @see https://github.com/hyperledger/cactus/issues/1471
+describe.skip("Deploy CC from Javascript Source Test", () => {
   let ledger: FabricTestLedgerV1;
   const contractName = "basic-asset-transfer-2";
   const contractRelPath =


### PR DESCRIPTION
Ran `go mod tidy` within the go chaincode directory of which the deploy
was failing:

`packages/cactus-plugin-ledger-connector-fabric/src/test/
typescript/fixtures/go/asset-transfer-private-data/chaincode-go/`

Also set `fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts` to be skipped
because it seems to have become flaky again. We have coverage for the same
functionality in other tests just not with the JS contract deployment
so it is not a big priority to have this test enabled. We expect most people
to use the Go/Typescript contracts anyway.

Fixes #3839

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.