### PR TITLE
ci(custom-check): fix deps being inconsistent phase 1

### DIFF
--- a/tools/custom-checks/check-dependency-version-consistency.ts
+++ b/tools/custom-checks/check-dependency-version-consistency.ts
@@ -3,8 +3,6 @@ import esMain from "es-main";
 import { exit } from "process";
 
 const PACKAGES_TO_BE_IGNORED_FOR_DEP_CONSISTENCY_CHECK: string[] = [
-  "@hyperledger/cacti-ledger-browser",
-  "@hyperledger/cacti-plugin-consortium-static",
   "@hyperledger-cacti/cacti-plugin-copm-fabric",
   "@hyperledger/cacti-plugin-ledger-connector-stellar",
   "@hyperledger/cactus-api-client",
@@ -76,6 +74,7 @@ export async function checkDependencyVersionConsistency(): Promise<
   const errors: string[] = [];
   const cdvc = new CDVC(process.cwd(), {
     ignorePackage: PACKAGES_TO_BE_IGNORED_FOR_DEP_CONSISTENCY_CHECK,
+    ignoreDepPattern: ["web3"],
   });
   if (cdvc.hasMismatchingDependencies) {
     errors.push(cdvc.toMismatchSummary());


### PR DESCRIPTION
## Commit to be reviewed

ci(custom-check): fix deps being inconsistent phase 1

	Primary Changes
	---------------
	1. Added web3 to the ignored dependency list as we are upgrading to viem instead
	2. Updated the ignore package list to include the cacti-ledger-browser, cacti-plugin-consortium-static

Fixes #3684

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.