### PR TITLE
fix(ledger-browser): supabase advisor errors and warnings

### DIFF
--- a/packages/cacti-ledger-browser/src/main/sql/schema.sql
+++ b/packages/cacti-ledger-browser/src/main/sql/schema.sql
@@ -1,5 +1,9 @@
+CREATE SCHEMA IF NOT EXISTS public;
+
 ALTER SCHEMA extensions OWNER TO postgres;
 ALTER SCHEMA public OWNER TO postgres;
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
 
 -- Table: public.plugin_status
 -- DROP TABLE IF EXISTS public.plugin_status;
@@ -19,6 +23,26 @@ TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS public.plugin_status
     OWNER to postgres;
+    
+ALTER TABLE public.plugin_status
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY plugin_status_select ON public.plugin_status
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY plugin_status_insert ON public.plugin_status
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY plugin_status_update ON public.plugin_status
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY plugin_status_delete ON public.plugin_status
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
 
 GRANT ALL ON TABLE public.plugin_status TO anon;
 GRANT ALL ON TABLE public.plugin_status TO authenticated;
@@ -45,6 +69,26 @@ TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS public.gui_app_config
     OWNER to postgres;
+
+ALTER TABLE public.gui_app_config
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY gui_app_config_select ON public.gui_app_config
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY gui_app_config_insert ON public.gui_app_config
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY gui_app_config_update ON public.gui_app_config
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY gui_app_config_delete ON public.gui_app_config
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
 
 GRANT ALL ON TABLE public.gui_app_config TO anon;
 GRANT ALL ON TABLE public.gui_app_config TO authenticated;

--- a/packages/cactus-plugin-persistence-ethereum/src/main/sql/schema.sql
+++ b/packages/cactus-plugin-persistence-ethereum/src/main/sql/schema.sql
@@ -25,6 +25,9 @@ TABLESPACE pg_default;
 ALTER TABLE IF EXISTS public.plugin_status
     OWNER to postgres;
 
+ALTER TABLE public.plugin_status
+ENABLE ROW LEVEL SECURITY;
+
 GRANT ALL ON TABLE public.plugin_status TO anon;
 GRANT ALL ON TABLE public.plugin_status TO authenticated;
 GRANT ALL ON TABLE public.plugin_status TO postgres;
@@ -49,6 +52,26 @@ CREATE TABLE IF NOT EXISTS ethereum.block
 ALTER TABLE IF EXISTS ethereum.block
     OWNER to postgres;
 
+ALTER TABLE ethereum.block
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY block_select ON ethereum.block
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY block_insert ON ethereum.block
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY block_update ON ethereum.block
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY block_delete ON ethereum.block
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 -- Table: ethereum.token_metadata_erc20
 
 -- DROP TABLE IF EXISTS ethereum."token_metadata_erc20";
@@ -67,6 +90,26 @@ CREATE TABLE IF NOT EXISTS ethereum."token_metadata_erc20"
 ALTER TABLE IF EXISTS ethereum."token_metadata_erc20"
     OWNER to postgres;
 
+ALTER TABLE ethereum."token_metadata_erc20"
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY token_metadata_erc20_select ON ethereum."token_metadata_erc20"
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY token_metadata_erc20_insert ON ethereum."token_metadata_erc20"
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY token_metadata_erc20_update ON ethereum."token_metadata_erc20"
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY token_metadata_erc20_delete ON ethereum."token_metadata_erc20"
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 -- Table: ethereum.token_metadata_erc721
 
 -- DROP TABLE IF EXISTS ethereum."token_metadata_erc721";
@@ -84,13 +127,33 @@ CREATE TABLE IF NOT EXISTS ethereum."token_metadata_erc721"
 ALTER TABLE IF EXISTS ethereum."token_metadata_erc721"
     OWNER to postgres;
 
+ALTER TABLE ethereum."token_metadata_erc721"
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY token_metadata_erc721_select ON ethereum."token_metadata_erc721"
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY token_metadata_erc721_insert ON ethereum."token_metadata_erc721"
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY token_metadata_erc721_update ON ethereum."token_metadata_erc721"
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY token_metadata_erc721_delete ON ethereum."token_metadata_erc721"
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 -- Table: ethereum.token_erc721
 
 -- DROP TABLE IF EXISTS ethereum.token_erc721;
 
 CREATE TABLE IF NOT EXISTS ethereum.token_erc721
 (
-    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
     account_address text COLLATE pg_catalog."default" NOT NULL,
     token_address text COLLATE pg_catalog."default" NOT NULL,
     uri text COLLATE pg_catalog."default" NOT NULL,
@@ -104,9 +167,28 @@ CREATE TABLE IF NOT EXISTS ethereum.token_erc721
         ON DELETE NO ACTION
 );
 
-
 ALTER TABLE IF EXISTS ethereum.token_erc721
     OWNER to postgres;
+
+ALTER TABLE ethereum.token_erc721
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY token_erc721_select ON ethereum.token_erc721
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY token_erc721_insert ON ethereum.token_erc721
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY token_erc721_update ON ethereum.token_erc721
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY token_erc721_delete ON ethereum.token_erc721
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
 
 -- Table: ethereum.transaction
 
@@ -114,7 +196,7 @@ ALTER TABLE IF EXISTS ethereum.token_erc721
 
 CREATE TABLE IF NOT EXISTS ethereum.transaction
 (
-    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
     index numeric NOT NULL,
     hash text COLLATE pg_catalog."default" NOT NULL,
     block_number numeric NOT NULL,
@@ -134,13 +216,33 @@ CREATE TABLE IF NOT EXISTS ethereum.transaction
 ALTER TABLE IF EXISTS ethereum.transaction
     OWNER to postgres;
 
+ALTER TABLE ethereum.transaction
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY transaction_select ON ethereum.transaction
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY transaction_insert ON ethereum.transaction
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY transaction_update ON ethereum.transaction
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY transaction_delete ON ethereum.transaction
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 -- Table: ethereum.token_transfer
 
 -- DROP TABLE IF EXISTS ethereum.token_transfer;
 
 CREATE TABLE IF NOT EXISTS ethereum.token_transfer
 (
-    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
     transaction_id uuid NOT NULL,
     sender text COLLATE pg_catalog."default" NOT NULL,
     recipient text COLLATE pg_catalog."default" NOT NULL,
@@ -155,6 +257,26 @@ CREATE TABLE IF NOT EXISTS ethereum.token_transfer
 ALTER TABLE IF EXISTS ethereum.token_transfer
     OWNER to postgres;
 
+ALTER TABLE ethereum.token_transfer
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY token_transfer_select ON ethereum.token_transfer
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY token_transfer_insert ON ethereum.token_transfer
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY token_transfer_update ON ethereum.token_transfer
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY token_transfer_delete ON ethereum.token_transfer
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 COMMENT ON COLUMN ethereum.token_transfer.value
     IS 'ERC20 - token quantity, ERC721 - token ID';
 
@@ -167,6 +289,7 @@ COMMENT ON COLUMN ethereum.token_transfer.value
 -- DROP VIEW ethereum.erc20_token_history_view;
 
 CREATE OR REPLACE VIEW ethereum.erc20_token_history_view
+WITH (security_invoker = on)
  AS
  SELECT
     tx.hash AS transaction_hash,
@@ -189,6 +312,7 @@ ALTER TABLE ethereum.erc20_token_history_view
 -- DROP VIEW ethereum.erc721_token_history_view;
 
 CREATE OR REPLACE VIEW ethereum.erc721_token_history_view
+WITH (security_invoker = on)
  AS
  SELECT tx.hash AS transaction_hash,
     tx."to" AS token_address,
@@ -255,7 +379,9 @@ CREATE UNIQUE INDEX token_erc20_uniq_idx
 
 -- Refresh ethereum.token_erc20 on new token transfers
 CREATE OR REPLACE FUNCTION refresh_token_erc20()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+SET search_path = ethereum
+AS $$
 BEGIN
     REFRESH MATERIALIZED VIEW ethereum.token_erc20;
     RETURN NULL;
@@ -273,6 +399,7 @@ EXECUTE FUNCTION refresh_token_erc20();
 
 CREATE OR REPLACE PROCEDURE ethereum.update_issued_erc721_tokens(IN from_block_number numeric)
 LANGUAGE 'plpgsql'
+SET search_path = ethereum, public
 AS $BODY$
 DECLARE
   current_token_entry ethereum.token_erc721%ROWTYPE;
@@ -342,6 +469,7 @@ CREATE OR REPLACE FUNCTION ethereum.get_missing_blocks_in_range(
   end_number integer)
 RETURNS TABLE(block_number integer)
 LANGUAGE 'plpgsql'
+SET search_path = ethereum
 COST 100
 VOLATILE PARALLEL UNSAFE
 ROWS 1000
@@ -367,3 +495,6 @@ GRANT ALL ON ALL SEQUENCES IN SCHEMA ethereum TO anon, authenticated, service_ro
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ethereum GRANT ALL ON TABLES TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ethereum GRANT ALL ON ROUTINES TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ethereum GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+
+REVOKE ALL ON ethereum.token_erc20 FROM anon, authenticated;
+GRANT SELECT ON ethereum.token_erc20 TO service_role;

--- a/packages/cactus-plugin-persistence-ethereum/src/test/typescript/integration/persistence-ethereum-postgresql-db-client.test.ts
+++ b/packages/cactus-plugin-persistence-ethereum/src/test/typescript/integration/persistence-ethereum-postgresql-db-client.test.ts
@@ -7,7 +7,7 @@
 //////////////////////////////////
 
 const postgresImageName = "postgres";
-const postgresImageVersion = "14.6-alpine";
+const postgresImageVersion = "15.12-alpine";
 const testLogLevel: LogLevelDesc = "info";
 const sutLogLevel: LogLevelDesc = "info";
 const setupTimeout = 1000 * 60; // 1 minute timeout for setup

--- a/packages/cactus-plugin-persistence-fabric/src/main/sql/schema.sql
+++ b/packages/cactus-plugin-persistence-fabric/src/main/sql/schema.sql
@@ -25,6 +25,9 @@ TABLESPACE pg_default;
 ALTER TABLE IF EXISTS public.plugin_status
     OWNER to postgres;
 
+ALTER TABLE public.plugin_status
+ENABLE ROW LEVEL SECURITY;
+
 GRANT ALL ON TABLE public.plugin_status TO anon;
 GRANT ALL ON TABLE public.plugin_status TO authenticated;
 GRANT ALL ON TABLE public.plugin_status TO postgres;
@@ -41,8 +44,27 @@ CREATE TABLE fabric.block (
     transaction_count numeric DEFAULT '0'::numeric NOT NULL
 );
 
-
 ALTER TABLE fabric.block OWNER TO postgres;
+
+ALTER TABLE fabric.block
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY block_select ON fabric.block
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY block_insert ON fabric.block
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY block_update ON fabric.block
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY block_delete ON fabric.block
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
 
 ALTER TABLE ONLY fabric.block
     ADD CONSTRAINT block_pkey PRIMARY KEY (id);
@@ -50,9 +72,6 @@ ALTER TABLE ONLY fabric.block
     ADD CONSTRAINT block_hash_key UNIQUE (hash);
 ALTER TABLE ONLY fabric.block
     ADD CONSTRAINT block_number_key UNIQUE (number);
-
-CREATE UNIQUE INDEX block_hash_unique_idx ON fabric.block USING btree (hash);
-CREATE UNIQUE INDEX block_number_unique_idx ON fabric.block USING btree (number);
 
 --
 -- Name: certificate; Type: TABLE; Schema: fabric; Owner: postgres
@@ -82,14 +101,32 @@ CREATE TABLE fabric.certificate (
 
 ALTER TABLE fabric.certificate OWNER TO postgres;
 
+ALTER TABLE fabric.certificate
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY certificate_select ON fabric.certificate
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY certificate_insert ON fabric.certificate
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY certificate_update ON fabric.certificate
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY certificate_delete ON fabric.certificate
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 ALTER TABLE ONLY fabric.certificate
     ADD CONSTRAINT certifiate_pk PRIMARY KEY (id);
 ALTER TABLE ONLY fabric.certificate
     ADD CONSTRAINT certifiate_pem_unique UNIQUE (pem);
 ALTER TABLE ONLY fabric.certificate
     ADD CONSTRAINT certifiate_serial_number_unique UNIQUE (serial_number);
-
-CREATE UNIQUE INDEX certifiate_serial_number_unique_idx ON fabric.certificate USING btree (serial_number);
 
 --
 -- Name: transaction; Type: TABLE; Schema: fabric; Owner: postgres
@@ -109,6 +146,26 @@ CREATE TABLE fabric.transaction (
 
 
 ALTER TABLE fabric.transaction OWNER TO postgres;
+
+ALTER TABLE fabric.transaction
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY transaction_select ON fabric.transaction
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY transaction_insert ON fabric.transaction
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY transaction_update ON fabric.transaction
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY transaction_delete ON fabric.transaction
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
 
 ALTER TABLE ONLY fabric.transaction
     ADD CONSTRAINT transaction_pkey PRIMARY KEY (id);
@@ -131,6 +188,26 @@ CREATE TABLE fabric.transaction_action (
 
 ALTER TABLE fabric.transaction_action OWNER TO postgres;
 
+ALTER TABLE fabric.transaction_action
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY transaction_action_select ON fabric.transaction_action
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY transaction_action_insert ON fabric.transaction_action
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY transaction_action_update ON fabric.transaction_action
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY transaction_action_delete ON fabric.transaction_action
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 ALTER TABLE ONLY fabric.transaction_action
     ADD CONSTRAINT transaction_action_pkey PRIMARY KEY (id);
 
@@ -149,6 +226,26 @@ CREATE TABLE fabric.transaction_action_endorsement (
 
 ALTER TABLE fabric.transaction_action_endorsement OWNER TO postgres;
 
+ALTER TABLE fabric.transaction_action_endorsement
+ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY transaction_action_endorsement_select ON fabric.transaction_action_endorsement
+FOR SELECT TO anon, authenticated, service_role
+USING (true);
+
+CREATE POLICY transaction_action_endorsement_insert ON fabric.transaction_action_endorsement
+FOR INSERT TO anon, authenticated, service_role
+WITH CHECK (true);
+
+CREATE POLICY transaction_action_endorsement_update ON fabric.transaction_action_endorsement
+FOR UPDATE TO anon, authenticated, service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY transaction_action_endorsement_delete ON fabric.transaction_action_endorsement
+FOR DELETE TO anon, authenticated, service_role
+USING (true);
+
 ALTER TABLE ONLY fabric.transaction_action_endorsement
     ADD CONSTRAINT transaction_action_endorsements_pkey PRIMARY KEY (id);
 
@@ -161,6 +258,7 @@ CREATE OR REPLACE FUNCTION fabric.get_missing_blocks_in_range(
   end_number integer)
 RETURNS TABLE(block_number integer)
 LANGUAGE 'plpgsql'
+SET search_path = fabric
 COST 100
 VOLATILE PARALLEL UNSAFE
 ROWS 1000


### PR DESCRIPTION
Primary Change:
* SQL schema
    1. Enable RLS and set policy (Security Advisor, Type of Error)
    2. Set RLS policy (Security Advisor, Type of Info)
    3. Set search_path (Security Advisor, Type of Warning)
    4. Set security_invoker (Security Advisor, Type of Error)
    5. Reset GRANT of "ethereum.token_erc20" (Security Advisor, Type of Warning)
    6. Remove duplicate index (Performance Advisor, Type of Warning)
    7. Add public search path to use uuid_generate_v4()
* Test Code
    1. Upgrade persistence-ethereum-postgresql-db-client.test PostgreSQL version

Fixes #3551

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.