### PR TITLE
test(test-tooling): support for custom docker network for besu and ethereum test networks

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
@@ -24,6 +24,7 @@ export interface IBesuTestLedgerConstructorOptions {
   envVars?: string[];
   logLevel?: LogLevelDesc;
   emitContainerLogs?: boolean;
+  networkName?: string;
 }
 
 export const BESU_TEST_LEDGER_DEFAULT_OPTIONS = Object.freeze({
@@ -32,6 +33,7 @@ export const BESU_TEST_LEDGER_DEFAULT_OPTIONS = Object.freeze({
   rpcApiHttpPort: 8545,
   rpcApiWsPort: 8546,
   envVars: ["BESU_NETWORK=dev"],
+  networkName: "cactus-besu-test-network",
 });
 
 export const BESU_TEST_LEDGER_OPTIONS_JOI_SCHEMA: Joi.Schema =
@@ -48,6 +50,7 @@ export const BESU_TEST_LEDGER_OPTIONS_JOI_SCHEMA: Joi.Schema =
   });
 
 export class BesuTestLedger implements ITestLedger {
+  public static readonly CLASS_NAME = "BesuTestLedger";
   public readonly containerImageVersion: string;
   public readonly containerImageName: string;
   public readonly rpcApiHttpPort: number;
@@ -59,9 +62,13 @@ export class BesuTestLedger implements ITestLedger {
   private container: Container | undefined;
   private containerId: string | undefined;
 
+  private readonly networkName: string;
+
   constructor(public readonly options: IBesuTestLedgerConstructorOptions = {}) {
     if (!options) {
-      throw new TypeError(`BesuTestLedger#ctor options was falsy.`);
+      throw new TypeError(
+        `${BesuTestLedger.CLASS_NAME}#constructor options was falsy.`,
+      );
     }
     this.containerImageVersion =
       options.containerImageVersion ||
@@ -74,6 +81,8 @@ export class BesuTestLedger implements ITestLedger {
     this.rpcApiWsPort =
       options.rpcApiWsPort || BESU_TEST_LEDGER_DEFAULT_OPTIONS.rpcApiWsPort;
     this.envVars = options.envVars || BESU_TEST_LEDGER_DEFAULT_OPTIONS.envVars;
+    this.networkName =
+      options.networkName || BESU_TEST_LEDGER_DEFAULT_OPTIONS.networkName;
 
     this.emitContainerLogs = Bools.isBooleanStrict(options.emitContainerLogs)
       ? (options.emitContainerLogs as boolean)
@@ -98,18 +107,28 @@ export class BesuTestLedger implements ITestLedger {
     return `${this.containerImageName}:${this.containerImageVersion}`;
   }
 
-  public async getRpcApiHttpHost(): Promise<string> {
-    const ipAddress = "127.0.0.1";
-    const hostPort: number = await this.getRpcApiPublicPort();
-    return `http://${ipAddress}:${hostPort}`;
+  public async getRpcApiHttpHost(asLocalhost: boolean = true): Promise<string> {
+    if (asLocalhost) {
+      const ipAddress = "127.0.0.1";
+      const hostPort: number = await this.getRpcApiPublicPort();
+      return `http://${ipAddress}:${hostPort}`;
+    } else {
+      const hostIp: string = await this.getContainerIpAddress();
+      return `http://${hostIp}:${this.rpcApiHttpPort}`;
+    }
   }
 
-  public async getRpcApiWsHost(): Promise<string> {
-    const { rpcApiWsPort } = this;
-    const ipAddress = "127.0.0.1";
-    const containerInfo = await this.getContainerInfo();
-    const port = await Containers.getPublicPort(rpcApiWsPort, containerInfo);
-    return `ws://${ipAddress}:${port}`;
+  public async getRpcApiWsHost(asLocalhost: boolean = true): Promise<string> {
+    if (asLocalhost) {
+      const { rpcApiWsPort } = this;
+      const ipAddress = "127.0.0.1";
+      const containerInfo = await this.getContainerInfo();
+      const port = await Containers.getPublicPort(rpcApiWsPort, containerInfo);
+      return `ws://${ipAddress}:${port}`;
+    } else {
+      const hostIp: string = await this.getContainerIpAddress();
+      return `ws://${hostIp}:${this.rpcApiWsPort}`;
+    }
   }
 
   public async getFileContents(filePath: string): Promise<string> {
@@ -255,6 +274,17 @@ export class BesuTestLedger implements ITestLedger {
       this.log.debug(`Pulled ${imageFqn} OK. Starting container...`);
     }
 
+    if (this.networkName) {
+      const networks = await docker.listNetworks();
+      const networkExists = networks.some((n) => n.Name === this.networkName);
+      if (!networkExists) {
+        await docker.createNetwork({
+          Name: this.networkName,
+          Driver: "bridge",
+        });
+      }
+    }
+
     return new Promise<Container>((resolve, reject) => {
       const eventEmitter: EventEmitter = docker.run(
         imageFqn,
@@ -283,6 +313,7 @@ export class BesuTestLedger implements ITestLedger {
           },
           HostConfig: {
             PublishAllPorts: true,
+            NetworkMode: this.networkName,
           },
           Env: this.envVars,
         },
@@ -403,23 +434,22 @@ export class BesuTestLedger implements ITestLedger {
     }
   }
 
-  public async getContainerIpAddress(): Promise<string> {
+  public async getContainerIpAddress(
+    network: string = this.networkName || "bridge",
+  ): Promise<string> {
     const fnTag = "BesuTestLedger#getContainerIpAddress()";
     const aContainerInfo = await this.getContainerInfo();
 
-    if (aContainerInfo) {
-      const { NetworkSettings } = aContainerInfo;
-      const networkNames: string[] = Object.keys(NetworkSettings.Networks);
-      if (networkNames.length < 1) {
-        throw new Error(`${fnTag} container not connected to any networks`);
-      } else {
-        // return IP address of container on the first network that we found
-        // it connected to. Make this configurable?
-        return NetworkSettings.Networks[networkNames[0]].IPAddress;
-      }
-    } else {
+    if (!aContainerInfo) {
       throw new Error(`${fnTag} cannot find image: ${this.containerImageName}`);
     }
+    const { NetworkSettings } = aContainerInfo;
+    const networkNames: string[] = Object.keys(NetworkSettings.Networks);
+    if (networkNames.length < 1) {
+      throw new Error(`${fnTag} container not connected to any networks`);
+    }
+
+    return NetworkSettings.Networks[network].IPAddress;
   }
 
   private pullContainerImage(containerNameAndTag: string): Promise<unknown[]> {
@@ -457,5 +487,13 @@ export class BesuTestLedger implements ITestLedger {
         `BesuTestLedger#ctor ${validationResult.error.annotate()}`,
       );
     }
+  }
+
+  public getNetworkName(): string {
+    const fnTag = `${BesuTestLedger.CLASS_NAME}#getNetworkName()`;
+    if (this.networkName) {
+      return this.networkName;
+    }
+    throw new Error(`${fnTag} network name not set`);
   }
 }

--- a/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/fabric/fabric-test-ledger-v1.ts
@@ -99,7 +99,7 @@ const DEFAULT_OPTS = Object.freeze({
   envVars: new Map([["FABRIC_VERSION", "1.4.8"]]),
   stateDatabase: STATE_DATABASE.COUCH_DB,
   orgList: ["org1", "org2"],
-  networkName: "cactusfabrictestnetwork",
+  networkName: "cactus-fabric-test-network",
 });
 export const FABRIC_TEST_LEDGER_DEFAULT_OPTIONS = DEFAULT_OPTS;
 
@@ -136,7 +136,7 @@ export class FabricTestLedgerV1 implements ITestLedger {
 
   private readonly log: Logger;
 
-  private readonly networkName: string | undefined;
+  private readonly networkName: string;
   private container: Container | undefined;
   private containerId: string | undefined;
   private readonly useRunningLedger: boolean;


### PR DESCRIPTION
- Added support for running the Besu and Ethereum test ledgers within a custom Docker network, enabling connections without requiring host network mode.

- Complement of https://github.com/hyperledger-cacti/cacti/pull/3871.