### PR TITLE
fix(weaver): resource incorrect permission assignment

### DIFF
--- a/weaver/sdks/corda/src/main/kotlin/org/hyperledger/cacti/weaver/sdk/corda/CredentialsExtractor.java
+++ b/weaver/sdks/corda/src/main/kotlin/org/hyperledger/cacti/weaver/sdk/corda/CredentialsExtractor.java
@@ -151,6 +151,14 @@ public class CredentialsExtractor {
 							File outputDir = new File(tempStore + "root/");
 							if (!outputDir.exists()) {
 								outputDir.mkdirs();
+								// remove all privilege from all previous users
+								outputDir.setReadable(false, false);
+								outputDir.setWritable(false, false);
+								outputDir.setExecutable(false, false);
+								// add all privilege to owner
+								outputDir.setReadable(true, true); 
+    							outputDir.setWritable(true, true);    
+    							outputDir.setExecutable(true, true); 
 							}
 							JcaPEMWriter xwriter = new JcaPEMWriter(new FileWriter(tempStore + "root/rootcert.pem"));
 							xwriter.writeObject(xcert);
@@ -201,6 +209,14 @@ public class CredentialsExtractor {
 							File outputDir = new File(tmpStore);
 							if (!outputDir.exists()) {
 								outputDir.mkdirs();
+								// remove all permissions from all users (including owner)
+								outputDir.setReadable(false, false);
+								outputDir.setWritable(false, false);
+								outputDir.setExecutable(false, false);
+								// grant full permissions to owner only
+								outputDir.setReadable(true, true); 
+								outputDir.setWritable(true, true);    
+								outputDir.setExecutable(true, true); 
 							}
 							String filePath = tmpStore + tmpCertfiles[i] + ".pem";
 							JcaPEMWriter xwriter = new JcaPEMWriter(new FileWriter(filePath));


### PR DESCRIPTION
Primary change: Grant full permissions to owner only

Fixes #2769

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.