### PR TITLE
Enabled configuration of OTEL service name via environment variable

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/services/monitoring/monitor.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/services/monitoring/monitor.ts
@@ -147,7 +147,7 @@ export class MonitorService {
     }
 
     const resource = new Resource({
-      "service.name": "Satp-Hermes-Gateway",
+      "service.name": process.env.OTEL_SERVICE_NAME || "Satp-Hermes-Gateway",
     });
 
     if (!this.sdk) {


### PR DESCRIPTION
When running multiple functional instances of the SATP Gateway (one gateway for network 1, one gateway for network 2) you need for each instance a unique OTEL service name to keep logging, traces and metrics separated.

As per the documentation [here](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) I have used the standard environment variable `OTEL_SERVICE_NAME` to allow for this.
