### PR TITLE
test(ethereum): fix broken validations in tests

### DIFF
--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/plugin-ledger-connector-ethereum.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/plugin-ledger-connector-ethereum.ts
@@ -1003,6 +1003,13 @@ export class PluginLedgerConnectorEthereum
     req: DeployContractV1Request,
   ): Promise<RunTransactionResponse> {
     Checks.truthy(req, "deployContract() request arg");
+    this.ensureAllowedObjectKeys(req, [
+      "web3SigningCredential",
+      "contract",
+      "constructorArgs",
+      "gasConfig",
+      "value",
+    ]);
 
     if (isWeb3SigningCredentialNone(req.web3SigningCredential)) {
       throw new Error(`Cannot deploy contract with pre-signed TX`);
@@ -1135,6 +1142,7 @@ export class PluginLedgerConnectorEthereum
       args.methodName,
       "web3.eth method string must not be empty",
     );
+    this.validateRawWeb3EthMethodArgs(args);
 
     const looseWeb3Eth = this.web3.eth as any;
     // web3.eth methods in 4.X are stored in parent class
@@ -1152,6 +1160,31 @@ export class PluginLedgerConnectorEthereum
 
     const web3MethodArgs = args.params || [];
     return looseWeb3Eth[args.methodName](...web3MethodArgs);
+  }
+
+  private ensureAllowedObjectKeys(
+    object: object,
+    allowedKeys: string[],
+  ): void {
+    const unexpectedKeys = Object.keys(object as Record<string, unknown>).filter(
+      (key) => !allowedKeys.includes(key),
+    );
+
+    if (unexpectedKeys.length > 0) {
+      throw new Error(
+        `Unexpected properties in request: ${unexpectedKeys.join(", ")}`,
+      );
+    }
+  }
+
+  private validateRawWeb3EthMethodArgs(
+    args: InvokeRawWeb3EthMethodV1Request,
+  ): void {
+    const methodArgs = args.params || [];
+
+    if (args.methodName === "getBlock" && methodArgs.length < 1) {
+      throw new Error("web3.eth.getBlock requires at least one argument");
+    }
   }
 
   /**

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
@@ -247,23 +247,26 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("deployContract with additional parameters should fail", async () => {
-    try {
-      await apiClient.deployContract({
-        contract: {
-          contractJSON: HelloWorldContractJson,
-        },
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-        gas: 1000000,
-        fake: 4,
-      } as DeployContractV1Request);
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+    const deployWithUnexpectedFields = apiClient.deployContract({
+      contract: {
+        contractJSON: HelloWorldContractJson,
+      },
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      gas: 1000000,
+      fake: 4,
+    } as DeployContractV1Request);
+
+    await expect(deployWithUnexpectedFields).rejects.toMatchObject({
+      response: expect.objectContaining({
+        data: expect.objectContaining({
+          error: expect.stringContaining("fake"),
+        }),
+      }),
+    });
   });
 
   //////////////////////////////////

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -253,24 +253,27 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("deployContract with additional parameters should fail", async () => {
-    try {
-      await apiClient.deployContract({
-        contract: {
-          contractName: HelloWorldContractJson.contractName,
-          keychainId: keychainPlugin.getKeychainId(),
-        },
-        web3SigningCredential: {
-          ethAccount: WHALE_ACCOUNT_ADDRESS,
-          secret: "",
-          type: Web3SigningCredentialType.GethKeychainPassword,
-        },
-        gas: 1000000,
-        fake: 4,
-      } as DeployContractV1Request);
-      fail("Expected deployContract call to fail but it succeeded.");
-    } catch (error) {
-      console.log("deployContract failed as expected");
-    }
+    const deployWithUnexpectedFields = apiClient.deployContract({
+      contract: {
+        contractName: HelloWorldContractJson.contractName,
+        keychainId: keychainPlugin.getKeychainId(),
+      },
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      gas: 1000000,
+      fake: 4,
+    } as DeployContractV1Request);
+
+    await expect(deployWithUnexpectedFields).rejects.toMatchObject({
+      response: expect.objectContaining({
+        data: expect.objectContaining({
+          error: expect.stringContaining("fake"),
+        }),
+      }),
+    });
   });
 
   //////////////////////////////////

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
@@ -167,16 +167,13 @@ describe("invokeRawWeb3EthMethod Tests", () => {
   });
 
   test("invokeRawWeb3EthMethod with missing arg throws error (getBlock)", async () => {
-    try {
-      const connectorResponse = connector.invokeRawWeb3EthMethod({
-        methodName: "getBlock",
-      });
+    const connectorResponse = connector.invokeRawWeb3EthMethod({
+      methodName: "getBlock",
+    });
 
-      await connectorResponse;
-      fail("Calling getBlock with missing argument should throw an error");
-    } catch (err) {
-      expect(err).toBeTruthy();
-    }
+    await expect(connectorResponse).rejects.toThrow(
+      "web3.eth.getBlock requires at least one argument",
+    );
   });
 
   test("invokeRawWeb3EthMethod with invalid arg throws error (getBlock)", async () => {


### PR DESCRIPTION
## Summary

Fix broken Ethereum connector validation behavior and refactor the affected negative tests to use Jest rejection matchers.

## Changes

- reject unexpected top-level properties in `deployContract()` requests
- reject `web3.eth.getBlock` calls when required arguments are missing
- refactor the three affected negative tests away from `try/catch` assertions to Jest matchers

## Verification

Validated in an isolated checkout by running:

- `geth-invoke-web3-method-v1.test.ts`
- `geth-contract-deploy-and-invoke-using-json-object-v1.test.ts`
- `geth-contract-deploy-and-invoke-using-keychain-v1.test.ts`

Fixes #3475
Related to #3487