### PR TITLE
fix(weaver): remove sensitive logging

### DIFF
--- a/packages/cactus-plugin-ledger-connector-ethereum/src/scripts/get-ethereum-connector-status.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/scripts/get-ethereum-connector-status.ts
@@ -53,7 +53,8 @@ async function main(url: string, auth: AuthOptions = {}) {
       !connectorResponse.data.data ||
       connectorResponse.data.status !== 200
     ) {
-      console.log(connectorResponse.data);
+      const status = connectorResponse?.data?.status ?? "unknown";
+      console.log(`Unexpected connector response status: ${status}`);
       throw new Error("Invalid response from the connector");
     }
 

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/scripts/get-ethereum-connector-status.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/scripts/get-ethereum-connector-status.ts
@@ -53,7 +53,11 @@ async function main(url: string, auth: AuthOptions = {}) {
       !connectorResponse.data.data ||
       connectorResponse.data.status !== 200
     ) {
-      console.log(connectorResponse.data);
+      const status = connectorResponse?.data?.status ?? "unknown";
+      const dataPresent = connectorResponse?.data?.data !== undefined;
+      console.log(
+        `Invalid connector response: status=${status}, dataPresent=${dataPresent}`,
+      );
       throw new Error("Invalid response from the connector");
     }
 

--- a/weaver/core/drivers/fabric-driver/server/walletSetup.ts
+++ b/weaver/core/drivers/fabric-driver/server/walletSetup.ts
@@ -69,7 +69,7 @@ const walletSetup = async (
     );
   } else {
     // Enroll the admin user, and import the new identity into the wallet.
-    logger.debug(`Enrolling Admin... ${adminName}, ${adminSecret}`);
+    logger.debug(`Enrolling admin identity "${adminName}"`);
     const enrollment = await ca.enroll({
       enrollmentID: adminName,
       enrollmentSecret: adminSecret,

--- a/weaver/core/identity-management/iin-agent/src/fabric-ledger/networkUtils.ts
+++ b/weaver/core/identity-management/iin-agent/src/fabric-ledger/networkUtils.ts
@@ -15,6 +15,13 @@ import { MembershipManager } from "@hyperledger/cacti-weaver-sdk-fabric";
 import { getWallet } from "./walletUtils";
 import * as utils from "../common/utils";
 
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};
+
 // Get a handle to a network gateway using existing wallet credentials
 const getNetworkGateway = async (
   walletPath: string,
@@ -62,7 +69,9 @@ const getNetworkGateway = async (
     });
     return gateway;
   } catch (error) {
-    console.error(`Failed to instantiate network (channel): ${error}`);
+    console.error(
+      `Failed to instantiate network (channel): ${getErrorMessage(error)}`,
+    );
     throw error;
   }
 };
@@ -88,7 +97,7 @@ const getNetworkContract = async (
     const contract = network.getContract(chaincodeId);
     return { gateway: gateway, contract: contract };
   } catch (error) {
-    console.error(`Failed to connect to contract: ${error}`);
+    console.error(`Failed to connect to contract: ${getErrorMessage(error)}`);
     throw error;
   }
 };
@@ -120,7 +129,7 @@ async function getMSPConfiguration(
     gateway.disconnect();
     return membership;
   } catch (error) {
-    console.error(`Failed to submit transaction: ${error}`);
+    console.error(`Failed to submit transaction: ${getErrorMessage(error)}`);
     throw error;
   }
 }
@@ -153,7 +162,7 @@ async function getAllMSPConfigurations(
     gateway.disconnect();
     return membership;
   } catch (error) {
-    console.error(`Failed to submit transaction: ${error}`);
+    console.error(`Failed to submit transaction: ${getErrorMessage(error)}`);
     throw error;
   }
 }
@@ -186,7 +195,7 @@ async function invokeFabricChaincode(
     gatewayAndContract.gateway.disconnect();
     return result;
   } catch (error) {
-    console.error(`Failed to submit transaction: ${error}`);
+    console.error(`Failed to submit transaction: ${getErrorMessage(error)}`);
     throw error;
   }
 }
@@ -219,7 +228,7 @@ async function queryFabricChaincode(
     gatewayAndContract.gateway.disconnect();
     return result;
   } catch (error) {
-    console.error(`Failed to submit query: ${error}`);
+    console.error(`Failed to submit query: ${getErrorMessage(error)}`);
     throw error;
   }
 }

--- a/weaver/core/identity-management/iin-agent/src/fabric-ledger/walletUtils.ts
+++ b/weaver/core/identity-management/iin-agent/src/fabric-ledger/walletUtils.ts
@@ -54,7 +54,7 @@ const walletSetup = async (
     );
   } else {
     // Enroll the admin user, and import the new identity into the wallet.
-    console.log("Enrolling Admin...", adminName, adminSecret);
+    console.log(`Enrolling admin identity "${adminName}"`);
     const enrollment = await ca.enroll({
       enrollmentID: adminName,
       enrollmentSecret: adminSecret,


### PR DESCRIPTION
## Summary

Remove or sanitize sensitive logging in the code paths flagged by issue #2762.

## Changes

- stop logging full error objects in the Weaver Fabric network helpers and log only the error message
- stop logging the Fabric admin enrollment secret in `walletUtils`
- stop dumping the full connector response in the connector status script and log only the response status
- apply the connector script fix in the current Ethereum connector script, which appears to be the renamed successor of the older Quorum path referenced in the original scan

## Verification

- reviewed the affected call sites and kept the operational behavior unchanged apart from the sanitized logging output

Fixes #2762