### PR TITLE
feat(satp-hermes): implement lock expiration

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
@@ -343,7 +343,8 @@ export class Stage2ClientService extends SATPService {
             },
           );
 
-          sessionData.lockAssertionExpiration = BigInt(99999999999); //todo implement
+          sessionData.lockAssertionExpiration =
+            BigInt(Date.now()) + sessionData.lockExpirationTime;
 
           sessionData.lockAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.lockAssertionClaim.receipt),

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage2-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage2-server-service.ts
@@ -258,7 +258,14 @@ export class Stage2ServerService extends SATPService {
           throw new LockAssertionExpirationError(fnTag);
         }
 
-        sessionData.lockAssertionExpiration = request.lockAssertionExpiration; //todo check if expired
+        if (request.lockAssertionExpiration <= BigInt(Date.now())) {
+          throw new LockAssertionExpirationError(
+            fnTag,
+            "lock assertion already expired",
+          );
+        }
+
+        sessionData.lockAssertionExpiration = request.lockAssertionExpiration;
 
         if (
           sessionData.clientTransferNumber != "" &&

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/services.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/services.test.ts
@@ -706,6 +706,8 @@ describe("SATP Services Testing", () => {
     );
   });
   it("Service2Client lockAssertionRequest", async () => {
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
     //mock claims
 
     mockSession.getClientSessionData().lockAssertionClaim = create(
@@ -747,12 +749,16 @@ describe("SATP Services Testing", () => {
     expect(lockAssertionRequestMessage.common?.sequenceNumber).toBeDefined();
     expect(lockAssertionRequestMessage.lockAssertionClaim).toBeDefined();
     expect(lockAssertionRequestMessage.lockAssertionClaimFormat).toBeDefined();
-    expect(lockAssertionRequestMessage.lockAssertionExpiration).toBeDefined();
+    expect(lockAssertionRequestMessage.lockAssertionExpiration).toBe(
+      BigInt(1_700_000_001_000),
+    );
     expect(lockAssertionRequestMessage.clientTransferNumber).toBeDefined();
     expect(lockAssertionRequestMessage.clientSignature).toBeDefined();
     expect(
       lockAssertionRequestMessage.common?.hashPreviousMessage,
     ).toBeDefined();
+
+    nowSpy.mockRestore();
   });
   it("Service2Server checkLockAssertionRequest", async () => {
     expect(satpServerService2).toBeDefined();
@@ -764,6 +770,20 @@ describe("SATP Services Testing", () => {
       lockAssertionRequestMessage,
       mockSession,
     );
+  });
+  it("Service2Server checkLockAssertionRequest rejects expired locks", async () => {
+    const expiredRequest = {
+      ...lockAssertionRequestMessage,
+      lockAssertionExpiration: BigInt(1),
+    } as LockAssertionRequest;
+
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+    await expect(
+      satpServerService2.checkLockAssertionRequest(expiredRequest, mockSession),
+    ).rejects.toThrow("lockAssertionExpiration missing or faulty");
+
+    nowSpy.mockRestore();
   });
   it("Service2Server lockAssertionResponse", async () => {
     lockAssertionReceiptMessage =


### PR DESCRIPTION
## Summary
This PR implements the remaining lock-expiration handling for SATP Hermes stage 2.

It replaces the hardcoded lock assertion expiration placeholder with a timestamp derived from the negotiated `lockExpirationTime`, and it rejects already-expired lock assertions on the server side.

## Changes
- derive `lockAssertionExpiration` from `Date.now() + lockExpirationTime`
- reject expired lock assertion requests in the stage 2 server flow
- add unit coverage for the computed expiration timestamp and expired-request rejection

Closes #3783.

## Validation
- Not run in this environment due local checkout filesystem issues while preparing the change.
