### PR TITLE
fix(satp-hermes): fix caching, ClaimFormat check, network config

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/besu-leaf.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/besu-leaf.ts
@@ -736,7 +736,7 @@ export class BesuLeaf
         }
 
         const response = (await this.connector.invokeContract({
-          contractName: this.wrapperContractAddress,
+          contractName: this.wrapperContractName,
           contractAbi: SATPWrapperContract.abi,
           contractAddress: this.wrapperContractAddress,
           invocationType: EthContractInvocationType.Send,
@@ -796,7 +796,7 @@ export class BesuLeaf
         }
 
         const response = (await this.connector.invokeContract({
-          contractName: this.wrapperContractAddress,
+          contractName: this.wrapperContractName,
           contractAbi: SATPWrapperContract.abi,
           contractAddress: this.wrapperContractAddress,
           invocationType: EthContractInvocationType.Send,
@@ -1165,7 +1165,7 @@ export class BesuLeaf
         }
 
         const response = (await this.connector.invokeContract({
-          contractName: this.wrapperContractAddress,
+          contractName: this.wrapperContractName,
           contractAbi: SATPWrapperContract.abi,
           contractAddress: this.wrapperContractAddress,
           invocationType: invocationType,

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/ethereum-leaf.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/ethereum-leaf.ts
@@ -542,7 +542,7 @@ export class EthereumLeaf
 
     if (!this.isFullPluginOptions(options.connectorOptions)) {
       throw new ConnectorOptionsError(
-        "Invalid options provided to the FabricLeaf constructor. Please provide a valid IPluginLedgerConnectorEthereumOptions object.",
+        "Invalid options provided to the EthereumLeaf constructor. Please provide a valid IPluginLedgerConnectorEthereumOptions object.",
       );
     }
 

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/satp-bridge-execution-layer-implementation.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/satp-bridge-execution-layer-implementation.ts
@@ -267,7 +267,9 @@ export class SATPBridgeExecutionLayerImpl implements SATPBridgeExecutionLayer {
 
     this.claimType = options.claimType || ClaimFormat.DEFAULT;
 
-    if (!(this.claimType in options.leafBridge.getSupportedClaimFormats())) {
+    if (
+      !options.leafBridge.getSupportedClaimFormats().includes(this.claimType)
+    ) {
       throw new ClaimFormatError("Claim not supported by the bridge");
     }
     this.bridgeEndPoint = options.leafBridge;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/oracle/implementations/oracle-evm.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/oracle/implementations/oracle-evm.ts
@@ -21,7 +21,6 @@ import {
   Web3SigningCredentialPrivateKeyHex,
 } from "@hyperledger-cacti/cactus-plugin-ledger-connector-ethereum";
 import { IOracleEntryBase, IOracleListenerBase } from "../oracle-types";
-import { EthereumLeaf } from "../../bridge/leafs/ethereum-leaf";
 import { LedgerType } from "@hyperledger-cacti/cactus-core-api";
 import {
   ClaimFormatError,
@@ -106,7 +105,7 @@ export class OracleEVM extends OracleAbstract {
       ledgerType: options.networkIdentification.ledgerType,
     };
 
-    this.id = this.options.leafId || this.createId(EthereumLeaf.CLASS_NAME);
+    this.id = this.options.leafId || this.createId(OracleEVM.CLASS_NAME);
     this.keyPair = options.keyPair || Secp256k1Keys.generateKeyPairsBuffer();
 
     this.claimFormats = options.claimFormats
@@ -119,7 +118,7 @@ export class OracleEVM extends OracleAbstract {
 
     if (isWeb3SigningCredentialNone(options.signingCredential)) {
       throw new NoSigningCredentialError(
-        `${EthereumLeaf.CLASS_NAME}#constructor, options.signingCredential`,
+        `${OracleEVM.CLASS_NAME}#constructor, options.signingCredential`,
       );
     }
     this.signingCredential = options.signingCredential;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/oracle/oracle-execution-layer.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/oracle/oracle-execution-layer.ts
@@ -42,7 +42,7 @@ export class OracleExecutionLayer implements OracleExecutionLayer {
    *
    * @param options - The options for configuring the OracleExecutionLayer instance.
    *
-   * @throws {ClaimFormatError} If the provided claim type is not supported by the bridge.
+   * @throws {ClaimFormatError} If the provided claim type is not supported by the oracle.
    */
   constructor(public readonly options: IOracleExecutionLayerOptions) {
     const label = OracleExecutionLayer.CLASS_NAME;
@@ -55,8 +55,10 @@ export class OracleExecutionLayer implements OracleExecutionLayer {
 
     this.claimType = options.claimType || ClaimFormat.DEFAULT;
 
-    if (!(this.claimType in options.oracleImpl.getSupportedClaimFormats())) {
-      throw new ClaimFormatError("Claim not supported by the bridge");
+    if (
+      !options.oracleImpl.getSupportedClaimFormats().includes(this.claimType)
+    ) {
+      throw new ClaimFormatError("Claim not supported by the oracle");
     }
     this.oracleImpl = options.oracleImpl;
   }

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/public-api.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/public-api.ts
@@ -181,6 +181,17 @@ export {
 export { IBesuNetworkConfig } from "./cross-chain-mechanisms/bridge/bridge-types";
 
 /**
+ * Ethereum Network Configuration - Ethereum mainnet and compatible network integration options.
+ *
+ * @description
+ * Configuration interface for connecting SATP gateways to Ethereum networks,
+ * enabling cross-chain asset transfers between Ethereum and other supported networks.
+ *
+ * @see {@link INetworkOptions} for general network configuration interface
+ */
+export { IEthereumNetworkConfig } from "./cross-chain-mechanisms/bridge/bridge-types";
+
+/**
  * Gateway Identity Management - Gateway identification and network discovery.
  *
  * @description
@@ -226,7 +237,6 @@ export {
   type StepTagValidationResult,
 } from "./core/satp-protocol-map";
 
-/**
 /**
  * Fabric Network Validation - Hyperledger Fabric configuration validation utilities.
  *

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/besu-leaf.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/besu-leaf.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../main/typescript/generated/proto/cacti/satp/v02/common/message_pb";
 import { ClaimFormat } from "../../../../main/typescript/generated/proto/cacti/satp/v02/common/message_pb";
 import { LedgerType } from "@hyperledger-cacti/cactus-core-api";
+import { InvokeContractV1Request } from "@hyperledger-cacti/cactus-plugin-ledger-connector-besu";
 import { BesuTestEnvironment } from "../../test-utils";
 import {
   EvmFungibleAsset,
@@ -183,10 +184,26 @@ describe("Besu Leaf Test with Fungible Tokens", () => {
   });
 
   it("Should Lock a token", async () => {
+    const invokeContractSpy = jest.spyOn(
+      (besuLeaf as any).connector,
+      "invokeContract",
+    );
+
     const response = await besuLeaf.lockAsset(asset.id, 100 as Amount);
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
     expect(response.transactionReceipt).toBeDefined();
+
+    expect(invokeContractSpy).toHaveBeenCalled();
+    const invokeContractRequest = invokeContractSpy.mock
+      .calls[0][0] as InvokeContractV1Request;
+    expect(invokeContractRequest.contractName).toBe(
+      (besuLeaf as any).wrapperContractName,
+    );
+    expect(invokeContractRequest.contractName).not.toBe(
+      besuLeaf.getWrapperContract(TokenType.NONSTANDARD_FUNGIBLE),
+    );
+    invokeContractSpy.mockRestore();
 
     const response2 = (await besuLeaf.getAsset(asset.id)) as EvmFungibleAsset;
     expect(response2).toBeDefined();
@@ -220,10 +237,26 @@ describe("Besu Leaf Test with Fungible Tokens", () => {
   });
 
   it("Should Unlock a token", async () => {
+    const invokeContractSpy = jest.spyOn(
+      (besuLeaf as any).connector,
+      "invokeContract",
+    );
+
     const response = await besuLeaf.unlockAsset(asset.id, 100 as Amount);
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
     expect(response.transactionReceipt).toBeDefined();
+
+    expect(invokeContractSpy).toHaveBeenCalled();
+    const invokeContractRequest = invokeContractSpy.mock
+      .calls[0][0] as InvokeContractV1Request;
+    expect(invokeContractRequest.contractName).toBe(
+      (besuLeaf as any).wrapperContractName,
+    );
+    expect(invokeContractRequest.contractName).not.toBe(
+      besuLeaf.getWrapperContract(TokenType.NONSTANDARD_FUNGIBLE),
+    );
+    invokeContractSpy.mockRestore();
 
     const response2 = (await besuLeaf.getAsset(asset.id)) as EvmFungibleAsset;
     expect(response2).toBeDefined();
@@ -477,6 +510,11 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
   });
 
   it("Should Lock a token", async () => {
+    const invokeContractSpy = jest.spyOn(
+      (besuLeaf as any).connector,
+      "invokeContract",
+    );
+
     const response = await besuLeaf.lockAsset(
       nonFungibleAsset.id,
       Number(uniqueTokenId1) as UniqueTokenID,
@@ -484,6 +522,17 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
     expect(response.transactionReceipt).toBeDefined();
+
+    expect(invokeContractSpy).toHaveBeenCalled();
+    const invokeContractRequest = invokeContractSpy.mock
+      .calls[0][0] as InvokeContractV1Request;
+    expect(invokeContractRequest.contractName).toBe(
+      (besuLeaf as any).wrapperContractName,
+    );
+    expect(invokeContractRequest.contractName).not.toBe(
+      besuLeaf.getWrapperContract(TokenType.NONSTANDARD_NONFUNGIBLE),
+    );
+    invokeContractSpy.mockRestore();
 
     const response2 = (await besuLeaf.getAsset(
       nonFungibleAsset.id,
@@ -528,6 +577,11 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
   });
 
   it("Should Unlock a token", async () => {
+    const invokeContractSpy = jest.spyOn(
+      (besuLeaf as any).connector,
+      "invokeContract",
+    );
+
     const response = await besuLeaf.unlockAsset(
       nonFungibleAsset.id,
       Number(uniqueTokenId1) as UniqueTokenID,
@@ -535,6 +589,17 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
     expect(response.transactionReceipt).toBeDefined();
+
+    expect(invokeContractSpy).toHaveBeenCalled();
+    const invokeContractRequest = invokeContractSpy.mock
+      .calls[0][0] as InvokeContractV1Request;
+    expect(invokeContractRequest.contractName).toBe(
+      (besuLeaf as any).wrapperContractName,
+    );
+    expect(invokeContractRequest.contractName).not.toBe(
+      besuLeaf.getWrapperContract(TokenType.NONSTANDARD_NONFUNGIBLE),
+    );
+    invokeContractSpy.mockRestore();
 
     const response2 = (await besuLeaf.getAsset(
       nonFungibleAsset.id,

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/claim-format-validation.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/claim-format-validation.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "@jest/globals";
+import { ClaimFormat } from "../../../main/typescript/generated/proto/cacti/satp/v02/common/message_pb";
+import { SATPBridgeExecutionLayerImpl } from "../../../main/typescript/cross-chain-mechanisms/bridge/satp-bridge-execution-layer-implementation";
+import { OracleExecutionLayer } from "../../../main/typescript/cross-chain-mechanisms/oracle/oracle-execution-layer";
+import { ClaimFormatError } from "../../../main/typescript/cross-chain-mechanisms/common/errors";
+import { BridgeLeaf } from "../../../main/typescript/cross-chain-mechanisms/bridge/bridge-leaf";
+import { OracleAbstract } from "../../../main/typescript/cross-chain-mechanisms/oracle/oracle-abstract";
+import { MonitorService } from "../../../main/typescript/services/monitoring/monitor";
+
+const monitorService = MonitorService.createOrGetMonitorService({
+  enabled: false,
+});
+
+function makeLeaf(supportedFormats: ClaimFormat[]): BridgeLeaf {
+  return {
+    getSupportedClaimFormats: () => supportedFormats,
+  } as unknown as BridgeLeaf;
+}
+
+function makeOracle(supportedFormats: ClaimFormat[]): OracleAbstract {
+  return {
+    getSupportedClaimFormats: () => supportedFormats,
+  } as unknown as OracleAbstract;
+}
+
+describe("SATPBridgeExecutionLayerImpl claim format validation", () => {
+  it("constructs successfully when claim format is in supported list", () => {
+    const leaf = makeLeaf([ClaimFormat.DEFAULT]);
+    expect(
+      () =>
+        new SATPBridgeExecutionLayerImpl({
+          leafBridge: leaf,
+          claimType: ClaimFormat.DEFAULT,
+          monitorService,
+        }),
+    ).not.toThrow();
+  });
+
+  it("defaults to ClaimFormat.DEFAULT and constructs when DEFAULT is supported", () => {
+    const leaf = makeLeaf([ClaimFormat.DEFAULT]);
+    expect(
+      () =>
+        new SATPBridgeExecutionLayerImpl({
+          leafBridge: leaf,
+          monitorService,
+        }),
+    ).not.toThrow();
+  });
+
+  it("throws ClaimFormatError when claim format is not in supported list", () => {
+    const leaf = makeLeaf([ClaimFormat.DEFAULT]);
+    expect(
+      () =>
+        new SATPBridgeExecutionLayerImpl({
+          leafBridge: leaf,
+          claimType: ClaimFormat.BUNGEE,
+          monitorService,
+        }),
+    ).toThrow(ClaimFormatError);
+  });
+
+  it("throws ClaimFormatError when supported list is empty", () => {
+    const leaf = makeLeaf([]);
+    expect(
+      () =>
+        new SATPBridgeExecutionLayerImpl({
+          leafBridge: leaf,
+          claimType: ClaimFormat.DEFAULT,
+          monitorService,
+        }),
+    ).toThrow(ClaimFormatError);
+  });
+});
+
+describe("OracleExecutionLayer claim format validation", () => {
+  it("constructs successfully when claim format is in supported list", () => {
+    const oracle = makeOracle([ClaimFormat.DEFAULT]);
+    expect(
+      () =>
+        new OracleExecutionLayer({
+          oracleImpl: oracle,
+          claimType: ClaimFormat.DEFAULT,
+          monitorService,
+        }),
+    ).not.toThrow();
+  });
+
+  it("defaults to ClaimFormat.DEFAULT and constructs when DEFAULT is supported", () => {
+    const oracle = makeOracle([ClaimFormat.DEFAULT]);
+    expect(
+      () =>
+        new OracleExecutionLayer({
+          oracleImpl: oracle,
+          monitorService,
+        }),
+    ).not.toThrow();
+  });
+
+  it("throws ClaimFormatError when claim format is not in supported list", () => {
+    const oracle = makeOracle([ClaimFormat.DEFAULT]);
+    expect(
+      () =>
+        new OracleExecutionLayer({
+          oracleImpl: oracle,
+          claimType: ClaimFormat.BUNGEE,
+          monitorService,
+        }),
+    ).toThrow(ClaimFormatError);
+  });
+
+  it("throws ClaimFormatError when supported list is empty", () => {
+    const oracle = makeOracle([]);
+    expect(
+      () =>
+        new OracleExecutionLayer({
+          oracleImpl: oracle,
+          claimType: ClaimFormat.DEFAULT,
+          monitorService,
+        }),
+    ).toThrow(ClaimFormatError);
+  });
+});


### PR DESCRIPTION
Three bug fixes and one refactor in the satp-hermes plugin.

**Fix `Array.includes()` for ClaimFormat validation**
The `in` operator checks array indices, not values. Since `ClaimFormat.DEFAULT = 1`,
`1 in [1]` is `false` (only index `0` exists), causing every transfer to throw
`ClaimFormatError`. Both `SATPBridgeExecutionLayerImpl` and `OracleExecutionLayer`
constructors are updated to use `Array.prototype.includes()`. Unit tests added for
the supported, default-fallback, unsupported, and empty-list cases.

**Fix BesuLeaf `contractName` bug**
`lockAsset()`, `unlockAsset()`, and `runTransaction()` were passing
`wrapperContractAddress` as `contractName`, causing an ABI cache miss on every call.
Fixed to use `wrapperContractName`.

**Fix OracleEVM and EthereumLeaf class name references**
`OracleEVM` used `EthereumLeaf.CLASS_NAME` for `this.id` and in a
`NoSigningCredentialError` message — both replaced with `OracleEVM.CLASS_NAME`.
The `ConnectorOptionsError` in `EthereumLeaf`'s constructor incorrectly said
`"FabricLeaf"`; corrected to `"EthereumLeaf"`. Removed the now-unused
`EthereumLeaf` import from `OracleEVM`.

**Refactor: export `IEthereumNetworkConfig`**
Exports the configuration interface that consumers need to connect gateways to
Ethereum networks.
