### PR TITLE
ci(triage-gate): enforce PULL.md section 9

### DIFF
--- a/.github/workflows/triage-gate-sweep.yaml
+++ b/.github/workflows/triage-gate-sweep.yaml
@@ -1,0 +1,236 @@
+# Triage gate — sweep phase.
+#
+# Runs daily. For each open PR carrying the `Triage_Warning` label:
+#   * If the author is now exempt (hyperledger-cacti org member or
+#     Dependabot), remove the label silently.
+#   * If the PR now references a `Triage_Ready` issue, remove the label
+#     and mark the sticky comment resolved (self-heal).
+#   * If neither and the label has been on the PR for at least 7 days,
+#     close the PR with a comment linking PULL.md §9. The PR
+#     remains reopenable.
+#
+# Companion to triage-gate-warn.yaml — see the security notes there.
+# This workflow is `schedule`/`workflow_dispatch` only, so it never
+# touches PR-provided code and does not need the same set of hard rules,
+# but we still avoid `actions/checkout` and shell-interpolating any
+# PR-controlled data.
+
+name: "Triage Gate — Sweep"
+
+on:
+  schedule:
+    # Daily at 00:00 UTC.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'When true, log actions but do not modify PRs. Default false.'
+        required: false
+        default: 'false'
+        type: string
+
+concurrency:
+  group: triage-gate-sweep-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Single source of truth for the label names, sticky-comment marker,
+# grace period, and internal tuning knobs. Keep in sync with
+# triage-gate-warn.yaml.
+env:
+  TRIAGE_WARN_LABEL: Triage_Warning
+  TRIAGE_READY_LABEL: Triage_Ready
+  TRIAGE_MARKER: '<!-- triage-bot -->'
+  TRIAGE_CLOSE_AFTER_DAYS: '7'
+  TRIAGE_MAX_PAGES: '5'
+  TRIAGE_BODY_MAX_BYTES: '16384'
+  TRIAGE_PULL_MD_URL: 'https://github.com/hyperledger-cacti/cacti/blob/main/PULL.md#9-linked-issue-and-traceability'
+
+permissions:
+  contents: read
+
+jobs:
+  triage-gate-sweep:
+    name: Close warned PRs after grace period
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Sweep PRs carrying Triage_Warning
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        env:
+          # `github.event.inputs.*` is `null` on schedule runs, which
+          # evaluates to 'false' via the `||` fallback below.
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const WARN_LABEL = process.env.TRIAGE_WARN_LABEL;
+            const READY_LABEL = process.env.TRIAGE_READY_LABEL;
+            const MARKER = process.env.TRIAGE_MARKER;
+            const CLOSE_AFTER_DAYS = Number(process.env.TRIAGE_CLOSE_AFTER_DAYS);
+            const MAX_PAGES = Number(process.env.TRIAGE_MAX_PAGES);
+            const BODY_MAX_BYTES = Number(process.env.TRIAGE_BODY_MAX_BYTES);
+            const dryRun = (process.env.DRY_RUN || 'false').toLowerCase() === 'true';
+            const { owner, repo } = context.repo;
+            const pullMdUrl = process.env.TRIAGE_PULL_MD_URL;
+
+            core.info(`Sweep starting (dryRun=${dryRun}).`);
+
+            // Search query uses only workflow constants — no PR-controlled
+            // data is interpolated. Safe against injection.
+            const query = `repo:${owner}/${repo} is:pr is:open label:"${WARN_LABEL}"`;
+            let searchPages = 0;
+            const results = await github.paginate(
+              github.rest.search.issuesAndPullRequests,
+              { q: query, per_page: 100 },
+              (response, done) => {
+                searchPages++;
+                if (searchPages >= MAX_PAGES) done();
+                // search endpoint wraps hits in { items: [...] }
+                return response.data.items;
+              },
+            );
+            core.info(`Found ${results.length} open PR(s) with ${WARN_LABEL} (capped at ${MAX_PAGES} pages).`);
+            
+            // Match warn workflow: only org owners/members and Dependabot
+            // are exempt. Outside collaborators still need Triage_Ready.
+            const exemptAssoc = new Set(['OWNER', 'MEMBER']);
+            const exemptBots = new Set(['dependabot[bot]']);
+            const now = Date.now();
+
+            const kwPattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|address(?:e[sd])?|refs?)\s+#(\d+)/gi;
+
+            for (const item of results) {
+              const num = item.number;
+
+              // Refresh authoritative PR state — search results can be stale.
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: num,
+              });
+
+              if (pr.draft) {
+                core.info(`#${num}: draft, skipping.`);
+                continue;
+              }
+
+              const login = (pr.user && pr.user.login) || '';
+              if (exemptAssoc.has(pr.author_association) || exemptBots.has(login)) {
+                core.info(`#${num}: exempt (${login}, ${pr.author_association}); clearing label.`);
+                if (!dryRun) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: num, name: WARN_LABEL,
+                    });
+                  } catch (err) {
+                    core.info(`#${num}: removeLabel: ${err.message}`);
+                  }
+                }
+                continue;
+              }
+
+              // Re-check conformance against current body (capped for safety).
+              const body = (pr.body || '').slice(0, BODY_MAX_BYTES);
+              const kw = new RegExp(kwPattern.source, kwPattern.flags);
+              const issueNumbers = new Set();
+              let m;
+              while ((m = kw.exec(body)) !== null) {
+                issueNumbers.add(Number(m[1]));
+              }
+
+              let conforming = false;
+              for (const n of issueNumbers) {
+                try {
+                  const { data: issue } = await github.rest.issues.get({
+                    owner, repo, issue_number: n,
+                  });
+                  if (issue.pull_request) continue;
+                  const labels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name));
+                  if (labels.includes(READY_LABEL)) {
+                    conforming = true;
+                    break;
+                  }
+                } catch (err) {
+                  core.info(`#${num}: could not fetch #${n}: ${err.message}`);
+                }
+              }
+
+              // Fetch the sticky bot comment once, before branching on conformance.
+              // It serves two purposes:
+              //   1. Self-heal (conforming path): update the comment to resolved.
+              //   2. Age source (non-conforming path): use created_at as the
+              //      label-age proxy instead of listEvents pagination.
+              let commentPages = 0;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: num, per_page: 100,
+              }, (response, done) => {
+                commentPages++;
+                if (commentPages >= MAX_PAGES) done();
+                return response.data;
+              });
+              const sticky = comments.find(c =>
+                (c.body || '').includes(MARKER)
+                && c.user
+                && c.user.type === 'Bot'
+                && c.user.login === 'github-actions[bot]'
+              );
+
+              if (conforming) {
+                core.info(`#${num}: now conforming; clearing label + resolving comment.`);
+                if (!dryRun) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: num, name: WARN_LABEL,
+                    });
+                  } catch (err) {
+                    core.info(`#${num}: removeLabel: ${err.message}`);
+                  }
+                  if (sticky) {
+                    const resolved = [
+                      MARKER,
+                      '',
+                      ':white_check_mark: This PR now references a `Triage_Ready` issue. Triage gate cleared.',
+                    ].join('\n');
+                    await github.rest.issues.updateComment({
+                      owner, repo, comment_id: sticky.id, body: resolved,
+                    });
+                  }
+                }
+                continue;
+              }
+
+              if (!sticky) {
+                core.info(`#${num}: Triage_Warning label present but sticky comment not found; skipping.`);
+                continue;
+              }
+
+              const ageDays = (now - new Date(sticky.created_at).getTime()) / (1000 * 60 * 60 * 24);
+              if (ageDays < CLOSE_AFTER_DAYS) {
+                core.info(`#${num}: warning issued ${ageDays.toFixed(1)}d ago (< ${CLOSE_AFTER_DAYS}d); leaving open.`);
+                continue;
+              }
+
+              core.info(`#${num}: warning issued ${ageDays.toFixed(1)}d ago; closing.`);
+              if (dryRun) continue;
+
+              const closeMsg = [
+                MARKER,
+                '',
+                ':x: **Closing per triage gate.**',
+                '',
+                `This PR has carried the \`${WARN_LABEL}\` label for more than ${CLOSE_AFTER_DAYS} days without being linked to a \`${READY_LABEL}\` issue.`,
+                '',
+                `See [PULL.md §9 — Linked Issue and Traceability](${pullMdUrl}).`,
+                '',
+                'You are welcome to reopen this PR once you have added a closing keyword (for example `Closes #1234`) pointing to a triaged issue.',
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: num, body: closeMsg,
+              });
+              await github.rest.pulls.update({
+                owner, repo, pull_number: num, state: 'closed',
+              });
+            }
+
+            core.info('Sweep complete.');

--- a/.github/workflows/triage-gate-warn.yaml
+++ b/.github/workflows/triage-gate-warn.yaml
@@ -1,0 +1,243 @@
+# Triage gate — warn phase.
+#
+# Enforces PULL.md §9 (Linked Issue and Traceability) and
+# AI_GUIDELINES.md §2.6 (Triage Gate for Agents): every PR must reference
+# an issue that carries the `Triage_Ready` label. If it does not, this
+# workflow adds the `Triage_Warning` label and posts (or edits) a single
+# sticky comment explaining the rule and the 7-day grace period. The
+# scheduled sweep workflow (triage-gate-sweep.yaml) later closes PRs that
+# remain non-conforming past the grace period.
+#
+# ============================================================
+# SECURITY — READ BEFORE MODIFYING
+# ============================================================
+# This workflow runs on `pull_request_target`, which is required so that
+# the GITHUB_TOKEN has write access when the PR comes from a fork; a
+# plain `pull_request` trigger would receive a read-only token and could
+# not comment/label. `pull_request_target` executes in the base repo
+# context and therefore has access to secrets and a writable token.
+# If PR-provided code were ever executed here, a malicious fork could
+# hijack the runner (the "pwn request" attack pattern).
+#
+# RULES for this workflow:
+#   1. NEVER `actions/checkout` the PR head. This job needs zero source
+#      files from the PR; it operates purely on the event payload and
+#      the REST API.
+#   2. NEVER run package managers, builds, tests, or any script that
+#      lives inside the PR (no `yarn`, `npm`, `pnpm`, `make`, `bash
+#      scripts/*`, etc.).
+#   3. The only step is `actions/github-script` to get PR context. All
+#      untrusted PR-controlled data (title, body, labels, author) is
+#      read via the JS `context` object; it is never interpolated into
+#      a shell `run:` block.
+#   4. `permissions:` are declared at the job level with the minimum
+#      scopes needed: comment/label/close on PRs, read issue labels.
+#   5. All third-party actions pinned to a full commit SHA.
+#
+#
+# See:
+#   - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#   - https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+# ============================================================
+
+name: "Triage Gate — Warn"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review]
+
+concurrency:
+  group: triage-gate-warn-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Single source of truth for the label names, sticky-comment marker,
+# grace period, and internal tuning knobs. Change here and both the warn
+# and sweep workflows stay in sync (keep values identical to
+# triage-gate-sweep.yaml).
+env:
+  TRIAGE_WARN_LABEL: Triage_Warning
+  TRIAGE_READY_LABEL: Triage_Ready
+  TRIAGE_WARN_LABEL_COLOR: d93b67
+  TRIAGE_MARKER: '<!-- triage-bot -->'
+  TRIAGE_CLOSE_AFTER_DAYS: '7'
+  # Cap pagination on comments/events so a maliciously noisy PR cannot
+  # force the workflow to walk unbounded API history.
+  TRIAGE_MAX_PAGES: '5'
+  # Slice PR body before regex work; defense-in-depth vs. large inputs.
+  TRIAGE_BODY_MAX_BYTES: '16384'
+  TRIAGE_PULL_MD_URL: 'https://github.com/hyperledger-cacti/cacti/blob/main/PULL.md#9-linked-issue-and-traceability'
+
+# Top-level default is read-only; the job below elevates to the minimum
+# scopes it needs. See the security notes at the top of this file.
+permissions:
+  contents: read
+
+jobs:
+  triage-gate-warn:
+    name: Enforce Triage_Ready link
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Check triage-ready linkage and warn if missing
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        with:
+          script: |
+            const WARN_LABEL = process.env.TRIAGE_WARN_LABEL;
+            const READY_LABEL = process.env.TRIAGE_READY_LABEL;
+            const WARN_LABEL_COLOR = process.env.TRIAGE_WARN_LABEL_COLOR;
+            const MARKER = process.env.TRIAGE_MARKER;
+            const CLOSE_AFTER_DAYS = Number(process.env.TRIAGE_CLOSE_AFTER_DAYS);
+            const MAX_PAGES = Number(process.env.TRIAGE_MAX_PAGES);
+            const BODY_MAX_BYTES = Number(process.env.TRIAGE_BODY_MAX_BYTES);
+
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.info('No pull_request payload; nothing to do.');
+              return;
+            }
+
+            if (pr.draft) {
+              core.info(`PR #${pr.number} is a draft; skipping.`);
+              return;
+            }
+
+            // Exemptions: hyperledger-cacti org members (author_association
+            // === 'MEMBER'; the org owner surfaces as 'OWNER') and
+            // Dependabot. Maintainers and code owners are covered in
+            // practice because they are org members. Outside collaborators
+            // (author_association === 'COLLABORATOR') and everyone else
+            // must still link a Triage_Ready issue.
+            const exemptAssoc = new Set(['OWNER', 'MEMBER']);
+            const exemptBots = new Set(['dependabot[bot]']);
+            const login = (pr.user && pr.user.login) || '';
+            if (exemptAssoc.has(pr.author_association) || exemptBots.has(login)) {
+              core.info(`Exempt author (${login}, ${pr.author_association}); skipping.`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const pullMdUrl = process.env.TRIAGE_PULL_MD_URL;
+
+            // Cap untrusted PR body before regex/scan work (BODY_MAX_BYTES
+            // is far more than any legitimate closing-keyword usage needs
+            // and removes any ReDoS/large-input concern).
+            const body = (pr.body || '').slice(0, BODY_MAX_BYTES);
+            const kw = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|address(?:e[sd])?|refs?)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+            let m;
+            while ((m = kw.exec(body)) !== null) {
+              issueNumbers.add(Number(m[1]));
+            }
+
+            let conforming = false;
+            for (const num of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner, repo, issue_number: num,
+                });
+                // Skip if the reference is actually a PR, not an issue.
+                if (issue.pull_request) continue;
+                const labels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name));
+                if (labels.includes(READY_LABEL)) {
+                  conforming = true;
+                  break;
+                }
+              } catch (err) {
+                core.info(`Could not fetch #${num}: ${err.message}`);
+              }
+            }
+
+            // Locate an existing sticky bot comment. The marker alone is not
+            // enough: an untrusted PR author could post a decoy comment with
+            // the marker in an attempt to make the bot overwrite/edit that
+            // comment. We additionally require the comment to have been
+            // authored by `github-actions[bot]`
+            let pageCount = 0;
+            const allComments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr.number, per_page: 100,
+            }, (response, done) => {
+              pageCount++;
+              if (pageCount >= MAX_PAGES) done();
+              return response.data;
+            });
+            const sticky = allComments.find(c =>
+              (c.body || '').includes(MARKER)
+              && c.user
+              && c.user.type === 'Bot'
+              && c.user.login === 'github-actions[bot]'
+            );
+
+            if (conforming) {
+              // Self-heal: clear the warning label and resolve the comment.
+              const hasLabel = (pr.labels || []).some(l => l.name === WARN_LABEL);
+              if (hasLabel) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: pr.number, name: WARN_LABEL,
+                  });
+                } catch (err) {
+                  core.info(`removeLabel: ${err.message}`);
+                }
+              }
+              if (sticky) {
+                const resolved = [
+                  MARKER,
+                  '',
+                  ':white_check_mark: This PR now references a `Triage_Ready` issue. Triage gate cleared.',
+                ].join('\n');
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: sticky.id, body: resolved,
+                });
+              }
+              return;
+            }
+
+            // Non-conforming: ensure the warning label exists (idempotent) and apply it.
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo,
+                name: WARN_LABEL,
+                color: WARN_LABEL_COLOR,
+                description: `PR does not link a ${READY_LABEL} issue; auto-close after ${CLOSE_AFTER_DAYS} days.`,
+              });
+            } catch (err) {
+              // 422 = already exists; that is the expected steady state.
+              core.info(`createLabel: ${err.message}`);
+            }
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: [WARN_LABEL],
+              });
+            } catch (err) {
+              core.info(`addLabels: ${err.message}`);
+            }
+
+            const warning = [
+              MARKER,
+              '',
+              ':warning: **Triage gate:** this PR does not reference a triaged issue.',
+              '',
+              `Every PR must be linked to an issue carrying the \`${READY_LABEL}\` label. See [PULL.md §9 — Linked Issue and Traceability](${pullMdUrl}).`,
+              '',
+              'Please edit the PR description to include a closing keyword and an issue number, for example:',
+              '',
+              '> `Closes #1234`',
+              '',
+              `The referenced issue must already carry \`${READY_LABEL}\` (assigned by a maintainer during triage).`,
+              '',
+              `:hourglass: If this is not resolved within **${CLOSE_AFTER_DAYS} days** of the \`${WARN_LABEL}\` label being applied, the PR will be closed automatically. You will be able to reopen it once the linkage is in place.`,
+              '',
+              'Members of the hyperledger-cacti GitHub organization and Dependabot are exempt from this check.',
+            ].join('\n');
+
+            if (sticky) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: sticky.id, body: warning,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number, body: warning,
+              });
+            }


### PR DESCRIPTION
Add two GitHub Actions workflows that implement
the triage gate described in PULL.md §9
(Linked Issue and Traceability) and
AI_GUIDELINES.md §2.6:

- triage-gate-warn.yaml. If the PR body does not reference an issue carrying `Triage_Ready`
via a closing keyword, the workflow applies
the `Triage_Warning` label and posts a single
sticky comment linking PULL.md §9 and the 7-day
grace period.

- triage-gate-sweep.yaml runs daily and on workflow_dispatch (with a `dry_run` input).
It closes any PR that has carried `Triage_Warning` for >= 7 days without becoming conforming,

Assisted-by: anthropic:claude-opus-4.8

<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

<!-- What does this PR do, and why? Keep it concise; reviewers should
     understand the change without reading every commit. -->

## Related issue

<!-- Every PR must reference an issue that has been triaged (labeled
     Triage_Ready). Use a closing keyword so GitHub links the issue:
       Full resolution:  Closes #N | Fixes #N | Resolves #N
       Partial progress: Addresses #N | Refs #N
     PRs that reference an issue still marked Triage_Needed, or that
     reference no issue at all, will be flagged (see PULL.md §9). -->

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
