### PR TITLE
docs: standardize tooling package documentation

### DIFF
--- a/packages/cactus-cmd-api-server/README.md
+++ b/packages/cactus-cmd-api-server/README.md
@@ -1,6 +1,7 @@
-# `@hyperledger/cactus-cmd-api-server` <!-- omit in toc -->
+# `@hyperledger-cacti/cactus-cmd-api-server` <!-- omit in toc -->
 
-- [Summary](#summary)
+- [Overview](#overview)
+- [Configuration](#configuration)
 - [Usage](#usage)
   - [Basic Example](#basic-example)
   - [Remote Plugin Imports at Runtime Example](#remote-plugin-imports-at-runtime-example)
@@ -10,7 +11,7 @@
 - [Containerization](#containerization)
   - [Building the container image locally](#building-the-container-image-locally)
   - [Running the container image locally](#running-the-container-image-locally)
-  - [Running Locally Built Image with Locally Modified Plugins Without npm/ghcr Publishishing](#running-locally-built-image-with-locally-modified-plugins-without-npmghcr-publishishing)
+  - [Running Locally Built Image with Locally Modified Plugins Without npm/ghcr Publishing](#running-locally-built-image-with-locally-modified-plugins-without-npmghcr-publishing)
   - [Testing API calls with the container](#testing-api-calls-with-the-container)
   - [Running a Security Scan on the Built Container Image](#running-a-security-scan-on-the-built-container-image)
 - [Prometheus Exporter](#prometheus-exporter)
@@ -21,13 +22,14 @@
         - [response.type.ts](#responsetypets)
         - [data-fetcher.ts](#data-fetcherts)
         - [metrics.ts](#metricsts)
+- [Testing](#testing)
 - [FAQ](#faq)
   - [What is the difference between a Cactus Node and a Cactus API Server?](#what-is-the-difference-between-a-cactus-node-and-a-cactus-api-server)
   - [Is the API server horizontally scalable?](#is-the-api-server-horizontally-scalable)
   - [Does the API server automatically protect me from malicious plugins?](#does-the-api-server-automatically-protect-me-from-malicious-plugins)
   - [Can I use the API server with plugins deployed as a service?](#can-i-use-the-api-server-with-plugins-deployed-as-a-service)
 
-## Summary
+## Overview
 
 This package is part of the Hyperledger Cactus blockchain integration framework
 and is used as a shell/container of sort for housing different Cactus plugins
@@ -37,6 +39,51 @@ The API server gives you for free the following benefits, should you choose to
 use it:
 1. Automatic wiring of API endpoints for Cactus plugins which implement the `IPluginWebService` Typescript interface
 2. Lightweight inversion of control container provided to plugins in the form of the `PluginRegistry` so that plugins can depend on each other in a way that each plugin instance can be uniquely identified and obtained by other plugins. A great example of this in action is ledger connector plugins frequently using the `PluginRegistry` to look up instances of keychain plugins to get access to secrets that are needed for the connector plugins to accomplish certain tasks such as cryptographically signing some information or SSH-ing into a server instance in order to upload and deploy binary (or otherwise) artifacts of smart contracts.
+
+**Target Audience:**
+- [x] Developers
+- [x] Operators
+
+## Configuration
+
+The following configuration options are available for the API server:
+
+| Option | Environment Variable | Default | Description |
+|---|---|---|---|
+| `openApiValidationOffPkgs` | `OPEN_API_VALIDATION_OFF_PKGS` | `[]` | The list of package names for which OpenAPI validation should be disabled. This is useful when dealing with plugins that have incorrect or incomplete OpenAPI specifications or when there is a bug in the OpenAPI validator middleware that cause it to have false negatives during validation. |
+| `crpcHost` | `CRPC_HOST` | `127.0.0.1` | The host to bind the CRPC fastify instance to. Secure default is: 127.0.0.1. Use 0.0.0.0 to bind for any host. |
+| `crpcPort` | `CRPC_PORT` | `6000` | The HTTP port to bind the CRPC fastify server endpoints to. |
+| `pluginManagerOptionsJson` | `PLUGIN_MANAGER_OPTIONS_JSON` | `{}` | Can be used to override npm registry and authentication details for example. |
+| `authorizationProtocol` | `AUTHORIZATION_PROTOCOL` | `null` | The name of the authorization protocol to use. Accepted values are: JSON_WEB_TOKEN, NONE |
+| `authorizationConfigJson` | `AUTHORIZATION_CONFIG_JSON` | `null` | The JSON string to deserialize when configuring authorization. |
+| `plugins` | `PLUGINS` | `[]` | A collection of plugins to load at runtime. |
+| `configFile` | `CONFIG_FILE` | `""` | The path to a config file that holds the configuration itself which will be parsed and validated. |
+| `logLevel` | `LOG_LEVEL` | `"warn"` | The level at which loggers should be configured. Supported values include the following: error, warn, info, debug, trace |
+| `minNodeVersion` | `MIN_NODE_VERSION` | `"12.0.0"` | Determines the lower bound of NodeJS version that the API server will be willing to start on. |
+| `tlsDefaultMaxVersion` | `TLS_DEFAULT_MAX_VERSION` | `"TLSv1.3"` | Sets the DEFAULT_MAX_VERSION property of the built-in tls module of NodeJS. |
+| `cockpitEnabled` | `COCKPIT_ENABLED` | `false` | Enable Cockpit server. |
+| `cockpitHost` | `COCKPIT_HOST` | `"127.0.0.1"` | The host to bind the Cockpit webserver to. Secure default is: 127.0.0.1. Use 0.0.0.0 to bind for any host. |
+| `cockpitPort` | `COCKPIT_PORT` | `3000` | The HTTP port to bind the Cockpit webserver to. |
+| `cockpitWwwRoot` | `COCKPIT_WWW_ROOT` | `""` | The file-system path pointing to the static files of web application served as the cockpit by the API server. |
+| `cockpitCorsDomainCsv` | `COCKPIT_CORS_DOMAIN_CSV` | `""` | The Comma seperated list of domains to allow Cross Origin Resource Sharing from when serving static file requests. The wildcard (*) character is supported to allow CORS for any and all domains |
+| `cockpitTlsEnabled` | `COCKPIT_TLS_ENABLED` | `true` | Enable TLS termination on the server. Useful if you do not have/want to have a reverse proxy or load balancer doing the SSL/TLS termination in your environment. |
+| `cockpitApiProxyRejectUnauthorized` | `COCKPIT_API_PROXY_REJECT_UNAUTHORIZED` | `true` | When false: accept self signed certificates while proxying from the cockpit host to the API host. Acceptable for development environments, never use it in production. |
+| `cockpitMtlsEnabled` | `COCKPIT_MTLS_ENABLED` | `true` | Enable mTLS so that only clients presenting valid TLS certificate of their own will be able to connect to the cockpit |
+| `cockpitTlsCertPem` | `COCKPIT_TLS_CERT_PEM` | `null` | Either the file path to the cert file or the contents of it. Value is checked for existence on the file system as a path. |
+| `cockpitTlsKeyPem` | `COCKPIT_TLS_KEY_PEM` | `null` | Either the file path to the key file or the contents of it. Value is checked for existence on the file system as a path. |
+| `cockpitTlsClientCaPem` | `COCKPIT_TLS_CLIENT_CA_PEM` | `null` | Either the client cert file pat or the contents of it. Value is checked for existence on the file system as a path. |
+| `apiHost` | `API_HOST` | `"127.0.0.1"` | The host to bind the API to. Secure default is: 127.0.0.1. Use 0.0.0.0 to bind for any host. |
+| `apiPort` | `API_PORT` | `4000` | The HTTP port to bind the API server endpoints to. |
+| `apiCorsDomainCsv` | `API_CORS_DOMAIN_CSV` | `""` | The Comma seperated list of domains to allow Cross Origin Resource Sharing from when serving API requests. The wildcard (*) character is supported to allow CORS for any and all domains, however using it is not recommended unless you are developing or demonstrating something with Cactus. |
+| `apiTlsEnabled` | `API_TLS_ENABLED` | `true` | Enable TLS termination on the server. Useful if you do not have/want to have a reverse proxy or load balancer doing the SSL/TLS termination in your environment. |
+| `apiMtlsEnabled` | `API_MTLS_ENABLED` | `true` | Enable mTLS so that only clients presenting valid TLS certificate of their own will be able to connect to the web APIs |
+| `apiTlsCertPem` | `API_TLS_CERT_PEM` | `null` | Either the file path to the cert file or the contents of it. Value is checked for existence on the file system as a path. |
+| `apiTlsClientCaPem` | `API_TLS_CLIENT_CA_PEM` | `null` | Either the client cert file pat or the contents of it. Value is checked for existence on the file system as a path. |
+| `apiTlsKeyPem` | `API_TLS_KEY_PEM` | `null` | Either the file path to the key file or the contents of it. Value is checked for existence on the file system as a path. |
+| `grpcHost` | `GRPC_HOST` | `"127.0.0.1"` | The host to bind the gRPC server to. Secure default is: 127.0.0.1. Use 0.0.0.0 to bind for any host. |
+| `grpcPort` | `GRPC_PORT` | `5000` | The gRPC port to serve web services on. |
+| `grpcMtlsEnabled` | `GRPC_TLS_ENABLED` | `true` | Enable TLS termination on the grpc server. Useful if you do not have/want to have a reverse proxy or load balancer doing the SSL/TLS termination in your environment. |
+| `enableShutdownHook` | `ENABLE_SHUTDOWN_HOOK` | `true` | It will cause the API server to listen to OS process signals and will attempt to gracefully shut itself down in response to these when the flag is enabled (which is the default behavior). |
 
 ## Usage
 
@@ -206,6 +253,8 @@ of the machine they are hosted on:
 
 ![deployment-low-resource-example.png](https://github.com/hyperledger/cactus/raw/4a337be719a9d2e2ccb877edccd7849f4be477ec/whitepaper/deployment-low-resource-example.png)
 
+
+
 ## Containerization
 
 ### Building the container image locally
@@ -214,7 +263,7 @@ In the project root directory run these commands on the terminal:
 
 ```sh
 yarn configure
-yarn lerna run build:bundle --scope=@hyperledger/cactus-cmd-api-server
+yarn lerna run build:bundle --scope=@hyperledger-cacti/cactus-cmd-api-server
 
 ```
 
@@ -341,7 +390,7 @@ Once you've built the container, the following commands should work:
       --config-file=/.cacti-config.json
   ```
 
-### Running Locally Built Image with Locally Modified Plugins Without npm/ghcr Publishishing
+### Running Locally Built Image with Locally Modified Plugins Without npm/ghcr Publishing
 
 It can be very inconvenient to have to publish npm packages just for testing. If you'd like to
 evaluate some changes you've made in a plugin, but need to have the plugin installed in the API 
@@ -407,7 +456,7 @@ Don't have a Besu network on hand to test with? Test or develop against our Besu
 
 3. Terminal Window 3 (curl - replace eth accounts as needed)
     ```sh
-    curl --location --request POST 'http://127.0.0.1:4000/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-besu/run-transaction' \
+    curl --location --request POST 'http://127.0.0.1:4000/api/v1/plugins/@hyperledger-cacti/cactus-plugin-ledger-connector-besu/run-transaction' \
     --header 'Content-Type: application/json' \
     --data-raw '{
         "web3SigningCredential": {
@@ -518,6 +567,14 @@ This file lists all the prometheus metrics and what they are used for.
 
 
 
+
+## Testing
+
+To run the tests for this package, execute the following command:
+
+```sh
+yarn test
+```
 
 ## FAQ
 

--- a/packages/cactus-common/README.md
+++ b/packages/cactus-common/README.md
@@ -1,9 +1,89 @@
-# `@hyperledger/cactus-common`
+# `@hyperledger-cacti/cactus-common`
 
-> TODO: description
+> Universal library used by both front end and back end components of Cactus. Aims to be a developer swiss army knife.
+
+## Overview
+
+This module is a universal utility library used by both front-end and back-end Cacti components. It provides a wide range of shared functionalities to facilitate consistent logging, validation, cryptographic operations, error handling, and HTTP utilities across the project.
+
+**Target Audience:**
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-common
+```
+
+## API Summary
+
+### Logging
+- `LoggerProvider`
+- `Logger`
+- `ILoggerOptions`
+- `LogLevel`
+- `LogLevelNumbers`
+- `LogLevelDesc`
+
+### Validation & Guards
+- `Objects`
+- `Strings`
+- `Bools`
+- `Checks`
+- `isRecord`
+- `hasKey`
+
+### Cryptography
+- `JsObjectSigner`
+- `IJsObjectSignerOptions`
+- `SignatureFunction`
+- `VerifySignatureFunction`
+- `HashFunction`
+- `ISignerKeyPair`
+- `Secp256k1Keys`
+- `KeyFormat`
+- `KeyConverter`
+- `IJoseFittingJwtParams`
+- `isIJoseFittingJwtParams`
+
+### Error Handling
+- `CodedError`
+- `safeStringifyException`
+- `asError`
+- `coerceUnknownToError`
+- `createRuntimeErrorWithCause`
+- `newRex`
+- `ErrorFromUnknownThrowable`
+- `ErrorFromSymbol`
+
+### HTTP Utilities
+- `Http405NotAllowedError`
+- `ALL_EXPRESS_HTTP_VERB_METHOD_NAMES`
+- `ExpressHttpVerbMethodName`
+- `isExpressHttpVerbMethodName`
+- `isGrpcStatusObjectWithCode`
+- `HttpHeader`
+- `bigIntToDecimalStringReplacer`
+- `IAsyncProvider`
 
 ## Usage
 
+```typescript
+import { LoggerProvider, LogLevelDesc } from "@hyperledger-cacti/cactus-common";
+
+const log = LoggerProvider.getOrCreate({
+  label: "my-service",
+  level: "INFO" as LogLevelDesc,
+});
+
+log.info("Service initialized successfully.");
 ```
-// TODO: DEMONSTRATE API
+
+## Testing
+
+To run the tests for this package, execute the following command from the package root:
+
+```sh
+npx jest
 ```

--- a/packages/cactus-core-api/README.md
+++ b/packages/cactus-core-api/README.md
@@ -1,4 +1,6 @@
-# @hyperledger/cactus-core-api
+# @hyperledger-cacti/cactus-core-api
+
+## Overview
 
 This package is meant to be depended on by most of the other packages for interface
 definitions, abstract classes and generated code. All of which is to be kept with
@@ -7,26 +9,37 @@ dependencies.
 
 From the above it also comes that the `core-api` package is rarely used by developers who are implementing projects with Hyperledger Cactus and instead it is mostly consumed by the framework's other packages internally (e.g. the Hyperledger Cactus contributors).
 
-# Usage
+**Target Audience:**
+- [x] Developers
+- [ ] Operators
 
-## Installation
+## Install
 
 You can install the package via your favorite package manager.
 
 Yarn: 
 
-    yarn add --exact @hyperledger/cactus-core-api
+    yarn add --exact @hyperledger-cacti/cactus-core-api
 
 npm: 
 
-    npm install --save-exact=true @hyperledger/cactus-core-api
+    npm install --save-exact=true @hyperledger-cacti/cactus-core-api
 
 > We highly recommend using exact versions in general when managing your dependencies
 > in order to achieve (or get closer to) [reproducible builds](https://reproducible-builds.org/) and to enhance your
 > security posture against malicious package versions that might get pushed to the
 > registries without the knowledge or consent or well intentioned maintainers.
 
-## Import
+## API Summary
+
+- **Plugin Interfaces**: `ICactusPlugin`, `IPluginLedgerConnector`, `IPluginKeychain`, `IPluginWebService`, `IPluginObjectStore`
+- **Plugin Factories**: `PluginFactory`, `PluginFactoryFactory`
+- **gRPC/cRPC Services**: `IPluginGrpcService`, `IPluginCrpcService`
+- **Validation**: `createAjvTypeGuard`
+
+## Usage
+
+### Import
 
 ```typescript
 import {
@@ -38,7 +51,7 @@ import {
 } from "@hyperledger-cacti/cactus-core-api";
 ```
 
-## Check If POJO is a Cactus Plugin
+### Check If POJO is a Cactus Plugin
 
 ```typescript
 if (!isICactusPlugin(plugin)) {
@@ -46,9 +59,17 @@ if (!isICactusPlugin(plugin)) {
 }
 ```
 
-# Development
+## Testing
 
-## Weaver Protocol Buffers
+To run tests for this package:
+
+```sh
+yarn jest
+```
+
+## Development
+
+### Weaver Protocol Buffers
 
 To test the Rust build, you need to run either one of the following:
 

--- a/packages/cactus-core/README.md
+++ b/packages/cactus-core/README.md
@@ -1,18 +1,67 @@
-# `@hyperledger/cactus-core`
+# `@hyperledger-cacti/cactus-core`
 
-This module is responsible for providing the backbone for the rest of the packages
-when it comes to the features of Cactus.
+> Contains lower level abstractions and implementations shared by multiple higher level packages.
 
-The main difference between this and the `cactus-common` package is that this one
-does not guarantee it's features to work in the browser.
+## Overview
 
-The main difference from the `cactus-core-api` package is that this is meant to
-contain actual implementations while `cactus-core-api` is meant to be strictly
-about defining interfaces. Based on that latter constraint we may move the
-`PluginRegistry` out of that package and into this one in the near future.
+This module is responsible for providing the backbone for the rest of the packages when it comes to the features of Cacti. The main difference between this and the `cactus-common` package is that this one does not guarantee its features to work in the browser. The main difference from the `cactus-core-api` package is that this is meant to contain actual implementations while `cactus-core-api` is meant to be strictly about defining interfaces.
+
+**Target Audience:**
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-core
+```
+
+## API Summary
+
+### Plugin Management
+- `IPluginRegistryOptions`
+- `PluginRegistry`
+
+### Web Service Infrastructure
+- `registerWebServiceEndpoint`
+- `AuthorizationOptionsProvider`
+- `IEndpointAuthzOptionsProviderOptions`
+- `IInstallOpenapiValidationMiddlewareRequest`
+- `installOpenapiValidationMiddleware`
+- `GetOpenApiSpecV1EndpointBase`
+- `IGetOpenApiSpecV1EndpointBaseOptions`
+- `stringifyBigIntReplacer`
+- `IConfigureExpressAppContext`
+- `configureExpressAppBase`
+- `CACTI_CORE_CONFIGURE_EXPRESS_APP_BASE_MARKER`
+
+### Error Handling
+- `IHandleRestEndpointExceptionOptions`
+- `handleRestEndpointException`
+
+### Consortium
+- `ConsortiumRepository`
+- `IConsortiumRepositoryOptions`
+
+### Consensus
+- `consensusHasTransactionFinality`
 
 ## Usage
 
+```typescript
+import { PluginRegistry } from "@hyperledger-cacti/cactus-core";
+
+const registry = new PluginRegistry({
+  plugins: [],
+});
+
+console.log("Plugin registry created successfully.");
 ```
-// TODO: DEMONSTRATE API
+
+## Testing
+
+To run the tests for this package, execute the following command from the package root:
+
+```sh
+npx jest
 ```

--- a/packages/cactus-test-tooling/README.md
+++ b/packages/cactus-test-tooling/README.md
@@ -1,35 +1,85 @@
-# `@hyperledger/cactus-test-tooling`
+# `@hyperledger-cacti/cactus-test-tooling`
 
-> TODO: description
+> Swiss army knife for test development. Main goal is to make pulling up test/dummy ledgers on the fly for tests easy, especially for test cases that are about simulating clean ledger state or wiped ledger state, etc.
+
+## Overview
+Test infrastructure harness for spinning up ephemeral DLT nodes and support services in Docker during test execution. 
+
+**Target Audience:**
+- [x] Developers
+- [ ] Operators
+
+## Prerequisites
+- Node.js >= 18
+- Docker daemon must be running
+
+## Install
+```bash
+npm install --save-dev @hyperledger-cacti/cactus-test-tooling
+```
+
+## API Summary
+
+### Supported Test Ledgers
+
+| Ledger Class | DLT / Network |
+|---|---|
+| `BesuTestLedger` | Besu |
+| `BesuMpTestLedger` | Besu |
+| `CordaTestLedger` | Corda |
+| `CordaV5TestLedger` | Corda |
+| `DamlTestLedger` | Daml |
+| `FabricTestLedgerV1` | Fabric |
+| `IndyTestLedger` | Indy |
+| `OpenEthereumTestLedger` | OpenEthereum |
+| `StellarTestLedger` | Stellar |
+| `SubstrateTestLedger` | Substrate |
+
+### Auxiliary Containers
+
+| Class | Description |
+|---|---|
+| `CordaConnectorContainer` | Container for Corda Connector |
+| `GoIpfsTestContainer` | IPFS Test Container |
+| `HttpEchoContainer` | HTTP Echo Server Container |
+| `KeycloakContainer` | Keycloak Server Container |
+| `LocalStackContainer` | LocalStack Container |
+| `PostgresTestContainer` | PostgreSQL Database Container |
+| `SATPGatewayRunner` | SATP Gateway Runner |
+| `VaultTestServer` | HashiCorp Vault Test Server |
+| `WsTestServer` | WS Identity Test Server |
+
+### Utilities
+- `Containers`: Helpers for Docker pruning and management.
+- `SelfSignedPkiGenerator`: Generates self-signed PKI for testing.
+- GitHub Actions helpers (`isRunningInGithubAction`, `pruneDockerAllIfGithubAction`, `pruneDockerContainersIfGithubAction`)
 
 ## Usage
 
+Here is a generic lifecycle pattern for spinning up a test ledger:
+
+```typescript
+import { BesuTestLedger } from "@hyperledger-cacti/cactus-test-tooling";
+
+const ledger = new BesuTestLedger();
+await ledger.start();
+
+const networkConfig = await ledger.getNetworkConfiguration();
+
+// ... run tests using the network configuration ...
+
+await ledger.stop();
+await ledger.destroy();
 ```
-// TODO: DEMONSTRATE API
-```
 
-## Docker image for the ws-identity server
+### Stellar Test Ledger Usage
 
-A docker image of the [ws-identity server](https://hub.docker.com/repository/docker/brioux/ws-identity) is used to test integration of WS-X.509 credential type in the fabric connector plugin.
-
-[ws-identity](https://github.com/brioux/ws-identity) includes A Docker file to build the image:
-clone the repo, install packages, build src and the image
-
-```
-npm install
-npm run build
-docker build . -t [image-name]
-```
-
-## Stellar Test Ledger Usage
-
-The Stellar test ledger follows the same structure present in the test ledger tools for other networks within the Cacti project. It pulls up and manages the [Stellar Quickstart Docker Image](https://github.com/stellar/quickstart) and can be used by importing the class `StellarTestLedger`, then instantiating it with some key optional arguments to define how the image should be configure.
+The Stellar test ledger follows the same structure present in the test ledger tools for other networks within the Cacti project. It pulls up and manages the [Stellar Quickstart Docker Image](https://github.com/stellar/quickstart) and can be used by importing the class `StellarTestLedger`, then instantiating it with some key optional arguments to define how the image should be configured.
 
 - `network`: Defines if the image should pull up a pristine local ledger or alternatively connect to an existing public test ledger. Defaults to `local`. It is important to note that connecting to an existing network can take up to several minutes to synchronize the ledger state.
+- `limits`: Defines the resource limits for soroban smart contract transactions. A valid transaction can only be included in a ledger block if enough resources are available for that operation. Defaults to `testnet`, which mimics the actual resource limits applied to the mainnet based on its test environment.
 
-- `limits`: Defines the resource limits for soroban smart contract transactions. A valid transaction and only be included in a ledger block if enough resources are available for that operation. Defaults to `testnet`, which mimics the actual resource limits applied to the mainnet based on its test environment.
-
-Once the class is successfully instantiated, one can start the environment by triggering
+Once the class is successfully instantiated, one can start the environment by triggering:
 
 ```typescript
 await stellarTestLedger.start();
@@ -37,13 +87,21 @@ await stellarTestLedger.start();
 
 The image will be pulled up and wait until the healthcheck ensures all of its services have started successfully and are accessible, then returns the container object.
 
-When integrating to a Stellar environment, it is common to use a few key services provided at different ports and paths. Once the class has been started, one can use the method `getNetworkConfiguration()` to get an object containing the required information to connect to this services.
+When integrating to a Stellar environment, it is common to use a few key services provided at different ports and paths. Once the class has been started, one can use the method `getNetworkConfiguration()` to get an object containing the required information to connect to these services.
 
 This object is already formatted to be used with the [stellar-plus](https://github.com/CheesecakeLabs/stellar-plus) open source js library to create a custom network configuration object that integrates with its provided tools, ensuring a frictionless development flow for this test ledger.
 
-Once the image have been fully utilized, one can fully stop and remove the environment by triggering
+Once the image has been fully utilized, one can fully stop and remove the environment by triggering:
 
 ```typescript
 await stellarTestLedger.stop();
 await stellarTestLedger.destroy();
+```
+
+## Testing
+
+To run tests for this package, use the `jest` command:
+
+```bash
+npx jest
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,24 @@
+# Cacti Development Tools
+
+> Collection of build scripts, CI utilities, custom validation checks, and Docker test ledger environments used across the Cacti monorepo.
+
+## Overview
+This directory contains various tooling essential for developing, building, and maintaining the Hyperledger Cacti monorepo. It includes continuous integration scripts, custom code quality checks, and pre-configured Docker environments for testing against different blockchain ledgers.
+
+**Target Audience:**
+- [x] Developers
+- [ ] Operators
+
+## Directory Index
+
+- **CI & Build**: 
+  - `ci.sh`: Main CI execution script.
+  - `commit-type-lint.sh`: Validates commit message formats.
+  - `lint-actions.sh`: Lints GitHub Actions workflows.
+  - `release.sh`: Release management script.
+- **Custom Checks**: Package validation suite. See [Custom Checks](./custom-checks/README.md).
+- **Docker Test Ledgers**: Pre-configured blockchain test environments. See [Docker](./docker/).
+- **Security**: 
+  - `supply-chain-attack-*`: Audit and scan scripts for dependencies.
+- **Monorepo Utilities**: 
+  - `sort-package-json.ts`, `sync-npm-deps-to-tsc-projects.ts`, `bump-openapi-spec-dep-versions.ts`: Utilities for maintaining monorepo consistency.

--- a/tools/custom-checks/README.md
+++ b/tools/custom-checks/README.md
@@ -1,0 +1,26 @@
+# Cacti Custom Checks
+
+> Monorepo integrity validation suite that runs as part of CI.
+
+## Overview
+This directory contains custom validation scripts that enforce consistency and integrity across the Cacti monorepo. These checks ensure that package files are sorted correctly, dependencies are consistent, and API specifications are valid.
+
+**Target Audience:**
+- [x] Developers
+- [ ] Operators
+
+## How to Run
+You can run the full suite of custom checks from the root directory using:
+```bash
+yarn custom-checks
+```
+
+## Available Checks
+
+- `check-package-json-sort.ts`: Ensures `package.json` files are consistently sorted.
+- `check-package-json-fields.ts`: Validates required fields and their values in `package.json` files.
+- `check-dependency-version-consistency.ts`: Checks that dependency versions match across the monorepo.
+- `check-sibling-dep-version-consistency.ts`: Ensures consistent versions for sibling dependencies.
+- `check-missing-node-deps.ts`: Identifies missing Node.js dependencies in packages.
+- `check-open-api-json-specs.ts`: Validates OpenAPI specification files.
+- `run-attw-on-tgz.ts`: Runs "Are the Types Wrong?" checks on generated tarballs.

--- a/tools/docker/besu-multi-party-all-in-one/README.md
+++ b/tools/docker/besu-multi-party-all-in-one/README.md
@@ -1,20 +1,24 @@
-# @hyperledger/cactus-besu-multi-party-all-in-one<!-- omit in toc -->
+# @hyperledger-cacti/cactus-besu-multi-party-all-in-one<!-- omit in toc -->
 
 ## Table of Contents<!-- omit in toc -->
 
-- [Summary](#summary)
-- [Usage via Public Container Registry](#usage-via-public-container-registry)
+- [Overview](#overview)
+- [How to Run via Public Container Registry](#how-to-run-via-public-container-registry)
 - [List endpoints and services](#list-endpoints-and-services)
 - [2021-06-16 22:23:46,653 DEBG 'besu-network' stdout output:](#2021-06-16-222346653-debg-besu-network-stdout-output)
 - [List endpoints and services](#list-endpoints-and-services-1)
 
-## Summary
+## Overview
 
 A container image that hosts a Besu network which is
 - Has multiple nodes and validators
 - Supports transaction privacy (`privateFrom` and `privateFor`)
 
-## Usage via Public Container Registry
+**Target Audience:**
+- [x] Developers
+- [x] Operators
+
+## How to Run via Public Container Registry
 
 ```sh
 docker run \

--- a/tools/docker/substrate-all-in-one/README.md
+++ b/tools/docker/substrate-all-in-one/README.md
@@ -1,16 +1,22 @@
-# @hyperledger/cactus-substrate-all-in-one<!-- omit in toc -->
+# @hyperledger-cacti/cactus-substrate-all-in-one<!-- omit in toc -->
+
+## Overview
 
 A container image that can holds the default Substrate test ledger (and the corresponding front-end).
 This image can be used for development of Substrate-based chains (including but not limited to pallets, smart contracts) and connectors.
 
 This is the test ledger used by the `polkadot-connector` package.
 
+**Target Audience:**
+- [x] Developers
+- [x] Operators
+
 ## Table of Contents<!-- omit in toc -->
 
-- [Usage](#usage)
+- [How to Run](#how-to-run)
 - [Build](#build)
 
-## Usage
+## How to Run
 To run the test ledger, use:
 
 ```sh


### PR DESCRIPTION
Apply README template to all tooling and core library packages per #4591.

Changes:
- Rewrite cactus-common README (was 96B stub with TODOs)
- Rewrite cactus-core README (was 648B with TODO usage section)
- Polish cactus-core-api README (add API summary, testing section)
- Add configuration reference table to cactus-cmd-api-server README
- Expand cactus-test-tooling README with full container matrix
- Create tools/README.md directory index
- Create tools/custom-checks/README.md
- Fix legacy @hyperledger/ npm scope across all package READMEs
- Fix Publishing typo in cactus-cmd-api-server README

<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

This PR standardizes the documentation for all core library and tooling packages by applying the README template agreed upon in the #4591 epic. It ensures that consumers and maintainers have a consistent, accurate source of truth for package capabilities, configuration options (like the new 30+ option table for `cactus-cmd-api-server`), and testing instructions. It also corrects legacy `@hyperledger/` npm scopes across these packages.

## Related issue

Closes #4593

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.

Assisted-by: Claude-Opus 4.6