### PR TITLE
ci(triage-gate): grant pull-requests write to allow comment and label PR

### DIFF
--- a/.github/workflows/triage-gate-warn.yaml
+++ b/.github/workflows/triage-gate-warn.yaml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       issues: write
+      pull-requests: write
       contents: read
     steps:
       - name: Check triage-ready linkage and warn if missing

--- a/tools/go-gen-checksum.sh
+++ b/tools/go-gen-checksum.sh
@@ -28,15 +28,15 @@ GOMODULE_PATHS=("weaver/common/protos-go"
 VERSION=${1:-"2.1.0"}
 OLD_VERSION=$(cat weaver/common/protos-go/VERSION)
 
-echo "REPO: $REPO"
-echo "OLD_VERSION: $OLD_VERSION"
-echo "VERSION: $VERSION"
-
 # Strip leading 'v' if present to normalize version
 NORMALIZED_VERSION=$VERSION
 if [ "${VERSION:0:1}" = "v" ]; then
   NORMALIZED_VERSION=${VERSION:1}
 fi
+
+echo "REPO: $REPO"
+echo "OLD_VERSION: $OLD_VERSION"
+echo "VERSION: $NORMALIZED_VERSION"
 
 # Extract major version from normalized VERSION
 MAJOR_VERSION=$(echo $NORMALIZED_VERSION | cut -d '.' -f 1)
@@ -225,33 +225,44 @@ update_import_paths() {
   done
 }
 
-# # First pass: Update testutils dependency if present
-# echo "========== PHASE 1: Updating testutils dependency =========="
-# TESTUTILS_MODULE="github.com/hyperledger-cacti/cacti/weaver/core/network/fabric-interop-cc/libs/testutils"
-# for GOMODULE in ${GOMODULE_PATHS[@]}; do
-#   if [ -f "$ROOT_DIR/$GOMODULE/go.mod" ]; then
-#     pushd "$ROOT_DIR/$GOMODULE" > /dev/null
+# First pass: Update testutils dependency if present
+echo "========== PHASE 1: Updating testutils dependency =========="
+TESTUTILS_MODULE="github.com/hyperledger-cacti/cacti/weaver/core/network/fabric-interop-cc/libs/testutils"
+for GOMODULE in ${GOMODULE_PATHS[@]}; do
+  if [ -f "$ROOT_DIR/$GOMODULE/go.mod" ]; then
+    pushd "$ROOT_DIR/$GOMODULE" > /dev/null
     
-#     # Check if testutils is a dependency
-#     if grep -q $TESTUTILS_MODULE go.mod; then
-#       echo "Updating testutils in $GOMODULE..."
+    # Check if testutils is a dependency
+    if grep -q $TESTUTILS_MODULE go.mod; then
+      echo "Updating testutils in $GOMODULE..."
 
-#       CURRENT_TESTUTILS_VERSION=$(go list -m -f '{{.Version}}' $TESTUTILS_MODULE)
-#       COMMIT_HASH=$(git rev-parse main)
-#       LATEST_TESTUTILS_VERSION=$(go list -m -f '{{.Version}}' $TESTUTILS_MODULE@$COMMIT_HASH)
-      
-#       if [ "$CURRENT_TESTUTILS_VERSION" != "$LATEST_TESTUTILS_VERSION" ]; then
-#         # Get latest testutils
-#         go mod edit -require=$TESTUTILS_MODULE@$LATEST_TESTUTILS_VERSION
-#         go mod tidy
-#       else
-#         echo "Skipping: testutils is already up to date in $GOMODULE"
-#       fi
-#     fi
+      CURRENT_TESTUTILS_VERSION=$(go list -m -f '{{.Version}}' $TESTUTILS_MODULE)
+      # testutils is never tagged/released; dependents pin it to a commit
+      # pseudo-version (v0.0.0-<date>-<hash>). Go can only resolve a commit
+      # into a pseudo-version if it exists on the REMOTE, so pin to the
+      # pushed tip of main. A local-only (unpushed) commit is an "unknown
+      # revision" to the module resolver.
+      COMMIT_HASH=$(git ls-remote origin refs/heads/main | cut -f1)
+      LATEST_TESTUTILS_VERSION=$(go list -m -f '{{.Version}}' $TESTUTILS_MODULE@$COMMIT_HASH)
+      if [ -z "$LATEST_TESTUTILS_VERSION" ]; then
+        echo "ERROR: could not resolve $TESTUTILS_MODULE at origin/main commit '$COMMIT_HASH'."
+        echo "       Push the latest testutils changes to origin/main and ensure 'go' can reach the module source."
+        popd > /dev/null
+        exit 1
+      fi
+
+      if [ "$CURRENT_TESTUTILS_VERSION" != "$LATEST_TESTUTILS_VERSION" ]; then
+        # Get latest testutils
+        go mod edit -require=$TESTUTILS_MODULE@$LATEST_TESTUTILS_VERSION
+        go mod tidy
+      else
+        echo "Skipping: testutils is already up to date in $GOMODULE"
+      fi
+    fi
     
-#     popd > /dev/null
-#   fi
-# done
+    popd > /dev/null
+  fi
+done
 
 # Second pass: Update import paths in source files
 echo "========== PHASE 2: Updating import paths in source files =========="
@@ -311,9 +322,11 @@ for GOMODULE in ${GOMODULE_PATHS[@]}; do
     echo "--------- START DEP -----------"
     GOMOD_DEP_VERSION=$(echo $GOMOD_DEP | awk -F "@" '{print $2}')
     GOMOD_DEP_MAJOR_VERSION=""
-    if [ "${GOMOD_DEP_VERSION:1:1}" -gt "1" ]; then
-      GOMOD_DEP_MAJOR_VERSION="/${GOMOD_DEP_VERSION:0:2}"
+    tmp=$(echo ${GOMOD_DEP_VERSION#v} | cut -d '.' -f 1)
+    if [ "$tmp" -gt "1" ]; then
+      GOMOD_DEP_MAJOR_VERSION="/v${tmp}"
     fi
+
     GOMOD_PATH=$(echo $GOMOD_DEP | awk -F "$GOMOD_DEP_MAJOR_VERSION@" '{print $1}' | awk -F "$REPO/" '{print $2}')
     echo DEP: $GOMOD_DEP
     echo DEP: $GOMOD_PATH
@@ -334,14 +347,29 @@ for GOMODULE in ${GOMODULE_PATHS[@]}; do
     echo "  Verifying dependencies in go.mod are updated..."
     if [ -f go.mod ]; then
       # Check if any old version references exist in go.mod
-      if grep -q "$REPO.*$OLD_MAJOR_VER v" go.mod 2>/dev/null; then
-        echo "  WARNING: Found old version references in $GOMOD_PATH/go.mod:"
-        grep "$REPO.*$OLD_MAJOR_VER v" go.mod
+      if [ "$OLD_MODULE_MAJOR_VER" != "$NEW_MAJOR_VER" ]; then
+        if grep -q "$REPO.*$OLD_MODULE_MAJOR_VER v" go.mod 2>/dev/null; then
+          echo "  WARNING: Found old version references in $GOMOD_PATH/go.mod:"
+          grep "$REPO.*$OLD_MODULE_MAJOR_VER v" go.mod
+          echo "  ERROR: Dependencies must be updated before calculating checksum"
+          popd > /dev/null
+          echo "------------ END --------------"
+          exit 1
+        fi
+      fi
+      # Now we are sure that any cacti dependency has the new major version.
+      # Also ensure those dependencies are pinned to the full new version
+      # (v$NORMALIZED_VERSION). testutils has no major suffix and uses a
+      # pseudo-version, so it is not matched here and is intentionally skipped.
+      if grep -E "$REPO.*$NEW_MAJOR_VER v" go.mod | grep -vqE " v$NORMALIZED_VERSION([[:space:]]|$)"; then
+        echo "  WARNING: Found cacti dependencies not at v$NORMALIZED_VERSION in $GOMOD_PATH/go.mod:"
+        grep -E "$REPO.*$NEW_MAJOR_VER v" go.mod | grep -vE " v$NORMALIZED_VERSION([[:space:]]|$)"
         echo "  ERROR: Dependencies must be updated before calculating checksum"
         popd > /dev/null
         echo "------------ END --------------"
         exit 1
       fi
+
       echo "  Verification passed: All dependencies updated to new version"
     fi
     
@@ -358,7 +386,7 @@ for GOMODULE in ${GOMODULE_PATHS[@]}; do
     
     pushd "$ROOT_DIR/$GOMODULE" > /dev/null
     UPDATE="false"
-    (cat go.mod | grep -q "$GOMOD_NAME $GOMOD_VERSION") || UPDATE="true"
+    (cat go.mod | grep -qE "$GOMOD_NAME $GOMOD_VERSION([[:space:]]|$)") || UPDATE="true"
     if [ "$UPDATE" = "true" ]; then
       # Remove old version entries using OLD_MAJOR_VER
       grep -v "$OLD_GOMOD_NAME v" go.mod > go.mod.tmp

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -32,7 +32,8 @@ function release() {
     if [ $? -ne 0 ]; then return 1; fi
     ./tools/weaver-update-version.sh $VERSION .
     if [ $? -ne 0 ]; then return 1; fi
-    git add . && git commit -s -m "chore(release): publish v$VERSION"
+    git add . && SKIP_FORBIDDEN_PATHS=1 git commit -s -m "chore(release): publish v$VERSION"
+    if [ $? -ne 0 ]; then return 1; fi
     return 0
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

* The warn job requested only `issues: write`, so commenting on and
labeling a pull request failed with "Resource not accessible by
integration" and crashed the step. Add `pull-requests: write`, matching
the scopes the sweep workflow already declares.

* Also exempt automated release PRs: skip the gate when the title starts
with `chore(release)` and the PR carries the `release` label. The label
is authoritative — only triage-or-higher users can apply it — so a title
alone cannot bypass triage. Untrusted PR fields are read via the
github-script context and never interpolated into a shell step.

* Also fixes go-gen-checksum script to work with same major upgrades

* And fixes release.sh to skip forbidden paths during commit

<!-- What does this PR do, and why? Keep it concise; reviewers should
     understand the change without reading every commit. -->

## Related issue

<!-- Every PR must reference an issue that has been triaged (labeled
     Triage_Ready). Use a closing keyword so GitHub links the issue:
       Full resolution:  Closes #N | Fixes #N | Resolves #N
       Partial progress: Addresses #N | Refs #N
     PRs that reference an issue still marked Triage_Needed, or that
     reference no issue at all, will be flagged (see PULL.md §9). -->

## PR author checklist

- [ ] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [ ] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
