### PR TITLE
fix(connector-fabric): send full/private blocks as JSON not binary

### DIFF
--- a/.github/actions/jest-runner/action.yaml
+++ b/.github/actions/jest-runner/action.yaml
@@ -15,6 +15,21 @@ inputs:
     description: "The name of the report"
     required: false
     default: "jest-tests-report"
+  jest_test_ignore:
+    description: >-
+      Regex of test paths to skip, passed through as --testPathIgnorePatterns.
+      NOTE: this REPLACES the list in jest.config.js rather than adding to it,
+      so only use it for patterns under the caller's own jest_test_pattern.
+    required: false
+    default: ""
+  jest_test_timeout:
+    description: >-
+      Per-test timeout in milliseconds, passed through as --testTimeout.
+      Leave empty to use the repo-wide jest.config.js value (1 hour).
+      NOTE: jest applies this to hooks as well, so it must stay above the
+      time a suite's beforeAll needs (a Fabric AIO ledger takes ~4 minutes).
+    required: false
+    default: ""
   github_secret:
     description: "GitHub secret for authentication"
     required: false
@@ -29,6 +44,8 @@ runs:
         mkdir -p reports
         export JEST_JUNIT_OUTPUT_FILE="reports/${{ inputs.report_name }}.xml"
         yarn jest "${{ inputs.jest_test_pattern }}" \
+          ${{ inputs.jest_test_timeout && format('--testTimeout={0}', inputs.jest_test_timeout) || '' }} \
+          ${{ inputs.jest_test_ignore && format('--testPathIgnorePatterns={0}', inputs.jest_test_ignore) || '' }} \
           --coverage \
           --coverageDirectory="${{ inputs.jest_test_coverage_path }}" \
           --reporters=default \
@@ -43,6 +60,8 @@ runs:
         mkdir -p reports
         export JEST_JUNIT_OUTPUT_FILE="reports/${{ inputs.report_name }}.xml"
         yarn jest "${{ inputs.jest_test_pattern }}" \
+          ${{ inputs.jest_test_timeout && format('--testTimeout={0}', inputs.jest_test_timeout) || '' }} \
+          ${{ inputs.jest_test_ignore && format('--testPathIgnorePatterns={0}', inputs.jest_test_ignore) || '' }} \
           --reporters=default \
           --reporters=jest-junit \
           --passWithNoTests \

--- a/.github/workflows/connector-packages-workflow.yaml
+++ b/.github/workflows/connector-packages-workflow.yaml
@@ -239,17 +239,44 @@ jobs:
           path: ./code-coverage-ts/**/
 
   cpl-connector-fabric-v2-2-x:
-    # Heavy suite: Fabric v2.2.x AIO integration tests. Runs on its own VM
-    # so each AIO container start is the first on the host (no port/state
-    # leakage from prior Jest files). The three deploy-cc-from-* tests are
-    # skipped via describe.skip pending FabricTestLedgerV1 teardown fixes.
-    # TODO: Set continue-on-error back to false once FabricTestLedgerV1
-    # teardown is fixed (see cpl-connector-fabric note above).
+    # Heavy suite: Fabric v2.2.x AIO integration tests, one shard per test file.
+    #
+    # Previously this ran all 13 files in a single job under `maxWorkers: 1`,
+    # and never finished: it completed 2 suites, then spent the rest of the
+    # hour inside fabric-watch-blocks-*-endpoint before `timeout-minutes: 60`
+    # cancelled it. `continue-on-error: true` meant that cancellation was
+    # reported as a pass, so 7 of the 9 live suites had no CI coverage at all.
+    #
+    # Sharding makes wall clock the slowest single suite rather than the sum,
+    # and isolates a hanging suite to its own shard instead of letting it
+    # consume the budget of every suite behind it. Measured per-suite runtimes
+    # on a native amd64 host: the healthy suites take 3-5 minutes each; the two
+    # watch-blocks suites do not terminate on their own.
+    #
+    # The three deploy-cc-from-* files and add-orgs are describe.skip'd in
+    # source, so those shards finish in seconds.
     if: contains(fromJson(inputs.affected-packages), 'packages/cactus-plugin-ledger-connector-fabric')
-    continue-on-error: true
-    timeout-minutes: 60
+    continue-on-error: false
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - add-orgs
+          - chaincode-event-listener
+          - connector-fabric-baseline
+          - delegate-signing-methods
+          - deploy-cc-from-golang-source
+          - deploy-cc-from-javascript-source
+          - deploy-cc-from-typescript-source
+          - fabric-watch-blocks-delegated-sign-v1-endpoint
+          - fabric-watch-blocks-v1-endpoint
+          - obtain-profiles
+          - run-transaction-endpoint-v1
+          - run-transaction-with-identities
+          - run-transaction-with-ws-ids
     env:
-      JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/.*\.test\.ts
+      JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/${{ matrix.suite }}\.test\.ts
       JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpl-connector-fabric-v2-2-x
     runs-on: ubuntu-22.04
     steps:
@@ -275,13 +302,26 @@ jobs:
           jest_test_pattern: ${{ env.JEST_TEST_PATTERN }}
           jest_test_coverage_path: ${{ env.JEST_TEST_COVERAGE_PATH }}
           github_secret: ${{ secrets.GITHUB_TOKEN }}
-          report_name: cpl-connector-fabric-v2-2-x-report
+          report_name: cpl-connector-fabric-v2-2-x-${{ matrix.suite }}-report
+          # 10 minutes: comfortably above the ~4 min a Fabric AIO beforeAll
+          # needs (jest applies --testTimeout to hooks too), and well above the
+          # slowest healthy suite, while still failing a hung test inside the
+          # job's 30 minute budget instead of silently eating it.
+          jest_test_timeout: "600000"
+          # TEMPORARY: the two fabric-watch-blocks-* suites never terminate on
+          # their own - the connector emits the block but the client never
+          # receives it, so the subscription retries until the peer's Deliver
+          # stream limit is hit. Quarantined here so the rest of the directory
+          # can run green; removed in the follow-up commit that fixes the
+          # connector. Safe as a CLI override because jest.config.js's own
+          # testPathIgnorePatterns list contains nothing under fabric-v2-2-x.
+          jest_test_ignore: "/node_modules/|fabric-v2-2-x/fabric-watch-blocks-(delegated-sign-)?v1-endpoint\\.test\\.ts"
 
       - name: Upload coverage reports as artifacts
         if: ${{ inputs.run_code_coverage == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          name: coverage-reports-28b
+          name: coverage-reports-28b-${{ matrix.suite }}
           path: ./code-coverage-ts/**/
   
   cpl-connector-ethereum:

--- a/.github/workflows/connector-packages-workflow.yaml
+++ b/.github/workflows/connector-packages-workflow.yaml
@@ -308,14 +308,6 @@ jobs:
           # slowest healthy suite, while still failing a hung test inside the
           # job's 30 minute budget instead of silently eating it.
           jest_test_timeout: "600000"
-          # TEMPORARY: the two fabric-watch-blocks-* suites never terminate on
-          # their own - the connector emits the block but the client never
-          # receives it, so the subscription retries until the peer's Deliver
-          # stream limit is hit. Quarantined here so the rest of the directory
-          # can run green; removed in the follow-up commit that fixes the
-          # connector. Safe as a CLI override because jest.config.js's own
-          # testPathIgnorePatterns list contains nothing under fabric-v2-2-x.
-          jest_test_ignore: "/node_modules/|fabric-v2-2-x/fabric-watch-blocks-(delegated-sign-)?v1-endpoint\\.test\\.ts"
 
       - name: Upload coverage reports as artifacts
         if: ${{ inputs.run_code_coverage == 'true' }}

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/watch-blocks/watch-blocks-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/watch-blocks/watch-blocks-v1-endpoint.ts
@@ -54,6 +54,31 @@ export interface IWatchBlocksV1EndpointConfiguration {
 }
 
 /**
+ * Convert a value into one that socket.io will send as a single JSON packet.
+ *
+ * socket.io inspects every outgoing payload for Buffer instances. If it finds
+ * any, it sends a *binary* packet: the JSON is emitted with each Buffer
+ * replaced by a `{_placeholder: true}` marker, followed by one attachment
+ * frame per Buffer, and the client only surfaces the event once it has
+ * reassembled all of them.
+ *
+ * A full or private Fabric BlockEvent carries ~27 Buffers (block header
+ * hashes, signatures, envelope payloads). Emitting one directly produced a
+ * packet the client never reassembled, so `WatchBlocksV1.Next` never fired,
+ * the subscription looked idle, and the client re-subscribed indefinitely -
+ * eventually exhausting the peer's `/protos.Deliver` concurrency limit.
+ * Filtered and the Cacti* block types were unaffected only because their
+ * payloads happen to contain no Buffers.
+ *
+ * Round-tripping through JSON replaces each Buffer with its plain
+ * `{type: "Buffer", data: [...]}` representation, which is what an HTTP client
+ * of this API would receive anyway, so the payload goes out as one JSON packet.
+ */
+function toSocketIoJsonSafe<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
  * Endpoint to watch for new blocks on fabric ledger and report them
  * to client using socketio.
  */
@@ -154,9 +179,12 @@ export class WatchBlocksV1Endpoint {
       return;
     }
 
-    socket.emit(WatchBlocksV1.Next, {
-      fullBlock: blockEvent,
-    });
+    socket.emit(
+      WatchBlocksV1.Next,
+      toSocketIoJsonSafe({
+        fullBlock: blockEvent,
+      }),
+    );
   }
 
   /**
@@ -179,9 +207,12 @@ export class WatchBlocksV1Endpoint {
       return;
     }
 
-    socket.emit(WatchBlocksV1.Next, {
-      filteredBlock: blockEvent,
-    });
+    socket.emit(
+      WatchBlocksV1.Next,
+      toSocketIoJsonSafe({
+        filteredBlock: blockEvent,
+      }),
+    );
   }
 
   /**
@@ -204,9 +235,12 @@ export class WatchBlocksV1Endpoint {
       return;
     }
 
-    socket.emit(WatchBlocksV1.Next, {
-      privateBlock: blockEvent,
-    });
+    socket.emit(
+      WatchBlocksV1.Next,
+      toSocketIoJsonSafe({
+        privateBlock: blockEvent,
+      }),
+    );
   }
 
   /**

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-delegated-sign-v1-endpoint.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-delegated-sign-v1-endpoint.test.ts
@@ -15,6 +15,11 @@ const fabricEnvCAVersion = "1.4.9";
 const ledgerChannelName = "mychannel";
 const ledgerContractName = "basic";
 
+// How long a single watchBlocks subscription may go without delivering an
+// event before the test gives up. Well above the few seconds a healthy
+// subscription needs, far below jest.config.js's 1 hour testTimeout.
+const WATCH_BLOCK_EVENT_TIMEOUT_MS = 60_000;
+
 // Log settings
 const testLogLevel: LogLevelDesc = "info"; // default: info
 const sutLogLevel: LogLevelDesc = "info"; // default: info
@@ -242,7 +247,24 @@ describe("watchBlocksDelegatedSignV1 of fabric connector tests", () => {
     triggerTransactionCreation = true,
   ) {
     // Start monitoring
+    // Bound the wait explicitly. Without this the only thing that can end a
+    // subscription that never delivers is jest's testTimeout, which this repo
+    // sets to an hour - so a broken emitter shows up as a silent hang that
+    // consumes the whole CI job instead of a failure naming the block type.
     const monitorPromise = new Promise<void>((resolve, reject) => {
+      const eventDeadline = setTimeout(() => {
+        reject(
+          new Error(
+            `Timed out after ${WATCH_BLOCK_EVENT_TIMEOUT_MS} ms waiting for a '${type}' block event ` +
+              `(monitor '${monitorName}'). The connector accepted the subscription but never ` +
+              `delivered a block to the client.`,
+          ),
+        );
+      }, WATCH_BLOCK_EVENT_TIMEOUT_MS);
+      const settle = (fn: () => void) => {
+        clearTimeout(eventDeadline);
+        fn();
+      };
       const watchObservable = apiClient.watchBlocksDelegatedSignV1({
         channelName: ledgerChannelName,
         signerCertificate: adminIdentity.credentials.certificate,
@@ -256,17 +278,17 @@ describe("watchBlocksDelegatedSignV1 of fabric connector tests", () => {
           try {
             checkEventCallback(event);
             subscription.unsubscribe();
-            resolve();
+            settle(resolve);
           } catch (err) {
             log.error("watchBlocksDelegatedSignV1() event check error:", err);
             subscription.unsubscribe();
-            reject(err);
+            settle(() => reject(err));
           }
         },
         error(err) {
           log.error("watchBlocksDelegatedSignV1() error:", err);
           subscription.unsubscribe();
-          reject(err);
+          settle(() => reject(err));
         },
       });
     });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-v1-endpoint.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-v1-endpoint.test.ts
@@ -59,6 +59,11 @@ const fabricEnvCAVersion = "1.4.9";
 const ledgerChannelName = "mychannel";
 const ledgerContractName = "basic";
 
+// How long a single watchBlocks subscription may go without delivering an
+// event before the test gives up. Well above the few seconds a healthy
+// subscription needs, far below jest.config.js's 1 hour testTimeout.
+const WATCH_BLOCK_EVENT_TIMEOUT_MS = 60_000;
+
 // Log settings
 const testLogLevel: LogLevelDesc = "info"; // default: info
 const sutLogLevel: LogLevelDesc = "info"; // default: info
@@ -236,7 +241,24 @@ describe("watchBlocksV1 of fabric connector tests", () => {
     triggerTransactionCreation = true,
   ) {
     // Start monitoring
+    // Bound the wait explicitly. Without this the only thing that can end a
+    // subscription that never delivers is jest's testTimeout, which this repo
+    // sets to an hour - so a broken emitter shows up as a silent hang that
+    // consumes the whole CI job instead of a failure naming the block type.
     const monitorPromise = new Promise<void>((resolve, reject) => {
+      const eventDeadline = setTimeout(() => {
+        reject(
+          new Error(
+            `Timed out after ${WATCH_BLOCK_EVENT_TIMEOUT_MS} ms waiting for a '${type}' block event ` +
+              `(monitor '${monitorName}'). The connector accepted the subscription but never ` +
+              `delivered a block to the client.`,
+          ),
+        );
+      }, WATCH_BLOCK_EVENT_TIMEOUT_MS);
+      const settle = (fn: () => void) => {
+        clearTimeout(eventDeadline);
+        fn();
+      };
       const watchObservable = apiClient.watchBlocksV1({
         channelName: ledgerChannelName,
         gatewayOptions: {
@@ -254,17 +276,17 @@ describe("watchBlocksV1 of fabric connector tests", () => {
           try {
             checkEventCallback(event);
             subscription.unsubscribe();
-            resolve();
+            settle(resolve);
           } catch (err) {
             log.error("watchBlocksV1() event check error:", err);
             subscription.unsubscribe();
-            reject(err);
+            settle(() => reject(err));
           }
         },
         error(err) {
           log.error("watchBlocksV1() error:", err);
           subscription.unsubscribe();
-          reject(err);
+          settle(() => reject(err));
         },
       });
     });


### PR DESCRIPTION
## Description

Step one: shard Fabric CI so it fails faster
Step two: fix the serialization issue

## Related issue

Refs #4472

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
