### PR TITLE
docs: unify key concepts page

### DIFF
--- a/docs/docs/concepts/asset-exchange.md
+++ b/docs/docs/concepts/asset-exchange.md
@@ -1,0 +1,9 @@
+This refers to the change of ownership of an asset in a source network and a corresponding change of ownership in another network. No asset leaves the network it resides in. The well-known terminology for asset exchange is 'Atomic Cross-Chain Swap'.
+
+_For example_: two parties with both Bitcoin and Ethereum accounts may trade Bitcoin for Ethereum based on an exchange rate agreed upon off-chain. We generalize this to permissioned networks, where it may be harder to provide guarantees of finality, and therby, atomicity.
+
+The figure below illustrates a typical asset exchange. Initially, Party X holds Asset M in Network A and Party Y holds Asset N in Network B. Through interoperation, an exchange occurs whereby Y holds M in A and X holds N in B. The changes in these two networks occur atomically. (_Note_: in such a use case, both X and Y must be members of both networks.) See [DvP in Financial Markets](user-stories/financial-markets.md) for an example scenario illustrating asset exchanges.
+
+![alt text](../../images-weaver-docs/use-cases/asset-exchange.png)
+
+Both the asset transfer and exchange patterns can be extrapolated to scenarios involving more than 2 parties, 2 assets, and 2 networks. The only fixed criterion is that the actions on all networks happen atomically. For the same reason, the infrastructure and protocols to support both asset transfers and exchanges overlap significantly.

--- a/docs/docs/concepts/asset-transfer.md
+++ b/docs/docs/concepts/asset-transfer.md
@@ -1,0 +1,5 @@
+This refers to the movement of an asset from its source ledger to a consuming ledger. Since assets has _singleton_ ownership and can't be _double spent_, the transfer of an asset should result in its burning or locking in the source ledger and its creation on the target ledger.
+
+A typical asset transfer use case is illustrated in the figure below, where Party X initially holds Asset in Network A, and through interoperation transfers Asset to Party Y in Network B. The loss of Asset to X in A must occur simultaneously with the gain of Asset for Y in B;. i.e, these transactions must be _atomic_. ("Holding an asset" refers to a record on a network's shared ledger representing the ownership of that asset by a given entity.)
+
+![alt text](../../images-weaver-docs/use-cases/asset-transfer.png)

--- a/docs/docs/concepts/connector.md
+++ b/docs/docs/concepts/connector.md
@@ -1,0 +1,19 @@
+---
+id: drivers
+title: Drivers
+---
+
+<!--
+ Copyright IBM Corp. All Rights Reserved.
+
+ SPDX-License-Identifier: CC-BY-4.0
+ -->
+
+> Also known as Driver
+
+The connector is responsible for all communication between the relay and its network. In the previous sections we have thought about the connector as a component of the relay. We have done this because conceptually it makes sense to think about it like that. However, in our reference implementation we have made it a separate process which communicates with the relay via gRPC, as shown below. There are two main reasons for this:
+
+1. There must exist a different connector for each network type (e.g. Fabric, Corda etc.) and therefore having the connector as a separate process makes it easy to "plug" different connectors into the relay.
+2. A possible use case of the relay is that a single relay instance may have multiple connectors (e.g. if multiple entities in the network want to run their own connectors). In this case, this plugin style approach of connectors makes it possible to do without having to modify code for each configuration.
+
+![](../images-weaver-docs/architecture-assets/driver_architecture.png)

--- a/docs/docs/concepts/data-sharing.md
+++ b/docs/docs/concepts/data-sharing.md
@@ -1,3 +1,5 @@
-# Data Sharing
+This refers to the transfer of data from its source ledger to a consuming ledger. (In many scenarios, data records in one network ledger may need to be shared with another network ledger in order to drive forward a process on the latter.) The data transferred can be the result of invoking a contract or a database query. There are no technical limits to the number of times a given piece of data can be copied to other ledgers.
 
-This is a basic interoperability mode or use case pattern. [Here](../weaver/interoperability-modes.md#data-sharing) is a description.
+The below figure illustrates this pattern, where initially, Data Record is maintained only on Network A's ledger, and through interoperation, a copy resides on Network B's ledger. (_Note_: the data record may be transformed within Network B during the sharing process before a transaction is committed to its ledger.) See [Global Trade](user-stories/global-trade.md) for an example scenario illustrating data sharing.
+
+![alt text](../../images-weaver-docs/use-cases/data-transfer.png)

--- a/docs/docs/concepts/identity.md
+++ b/docs/docs/concepts/identity.md
@@ -1,0 +1,20 @@
+---
+id: identity
+title: Identity
+---
+
+<!--
+ Copyright IBM Corp. All Rights Reserved.
+
+ SPDX-License-Identifier: CC-BY-4.0
+ -->
+
+Interoperation for asset or data transfers/exchanges relies on a message-passing infrastructure and pan-network data processing modules, as we have seen in earlier pages. But there is yet another crucial basis these data processing modules need to satisfy our design principles of network independence and avoidance of trust parties. This is the ability of a network as a whole and of its individual members to accurately identify and authenticate another network's members.
+
+Further, for the networks to remain independent and interact ad hoc with each other, we cannot impose a central authority that unifies their private identity management systems. So the identity basis of interoperation must be decentralized, leading inevitably to the requirement of exchanging identity information across networks as a pre-requisite for asset and data transfers/exchanges. This is illustrated in the figure below where interoperation protocols are classified in two planes (or tiers), data and identity, with the former depending on the latter.
+
+![alt text](../images-weaver-docs/architecture-assets/identity-data-planes.jpg)
+
+- In the __data plane__ lies the protocols that effect the actual exchanges of data and assets. The figure above illustrates a typical data-sharing instance, where the network at the left requests a data record from the right. The latter receives the request via the two relays (not explicitly marked in this diagram) and runs an access control check through consensus in its _interop module_ before responding with the data record and supporting proof. The network at the left receives the data and proof, again via the two relays, and verifies the data using the supplied proof. __Note: since a core part of both request and proof are digital signatures of network members, the ability to identify and authenticate network members is necessary to perform these endpoint functions__
+
+Here is where the __identity plane__ enters the picture, as a trust anchor for the data plane. The most general function of this plane is illustrated in the figure, where the networks get each others' identity and configuration (i.e., membership structure and network topology) information. This exchange has as its own trust basis (or dependency) a set of identity providers and verifiers. (_Note_: these identity providers and verifiers may belong to the two networks or they could be external entities.) The outcome of the exchange is a record of the other network's identity and configuration information on one's ledger, which can then be looked up in a data plane protocol instance.

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -4,16 +4,11 @@ Cacti's interoperability framework is built on several core concepts
 that define how cross-network transactions are structured, verified,
 and executed.
 
-!!! note "Work in Progress"
-    This section is being expanded. Many of these concepts are already
-    documented in detail within the
-    [Weaver documentation](../weaver/introduction.md) and will be
-    consolidated here in a future update.
-
-| Concept | Description | Current Documentation |
+| Concept | Description | Documentation |
 |---------|-------------|----------------------|
-| **Data Sharing** | Querying and verifying ledger state across networks without asset movement. | [Data Sharing](../weaver/interoperability-modes.md#data-sharing) |
-| **Asset Exchange** | Atomic swaps of assets between two parties on different ledgers using hash time-locked contracts. | [Asset Exchange](../weaver/getting-started/interop/asset-exchange/overview.md) |
-| **Asset Transfer** | Moving an asset from one network to another with provable burn-and-mint or lock-and-claim semantics. | [Asset Transfer](../weaver/getting-started/interop/asset-transfer.md) |
-| **Identity Management** | Establishing trust and verifying membership across independently governed networks. | [Decentralized Identity](../weaver/architecture-and-design/decentralized-identity.md) |
-| **Relay Architecture** | A protocol-neutral message routing layer that connects heterogeneous networks without shared middleware. | [Relay](../weaver/architecture-and-design/relay.md) |
+| **Asset Exchange** | Atomic swaps of assets between two parties on different ledgers using hash time-locked contracts. | [Asset Exchange](./asset-exchange.md) |
+| **Asset Transfer** | Moving an asset from one network to another with provable burn-and-mint or lock-and-claim semantics. | [Asset Transfer](./asset-transfer.md) |
+| **Data Sharing** | Querying and verifying ledger state across networks without asset movement. | [Data Sharing](./data-sharing.md) |
+| **Connector (or Driver)** | Plugin that abstract interaction for specific network. | [Connector](./connector.md) |
+| **Relay Architecture** | A protocol-neutral message routing layer that connects heterogeneous networks without shared middleware. | [Relay](./relay.md) |
+| **Identity Management** | Establishing trust and verifying membership across independently governed networks. | [Identity](./identity.md) |

--- a/docs/docs/concepts/relay.md
+++ b/docs/docs/concepts/relay.md
@@ -1,0 +1,29 @@
+---
+id: relay
+title: Relay
+---
+
+<!--
+ Copyright IBM Corp. All Rights Reserved.
+
+ SPDX-License-Identifier: CC-BY-4.0
+ -->
+
+![](../images-weaver-docs/architecture-assets/relay_architecture.png)
+
+As mentioned in the overview, relays facilitate communication of protocols between networks. To do this, they are composed of three main pieces:
+
+-   `Relay service` - A gRPC server that listens for and handles incoming requests from other relays. For example, a remote network requesting state.
+-   `App service` - A gRPC server that listens for and handles requests from applications that are requesting an asset from a remote network.
+-   `Driver` - The driver is responsible for all communication between the relay and its network. The driver is described in more detail in [drivers](./drivers.md).
+
+The diagram below shows an example communication between two networks, A and B, where network A is requesting state from network B.
+
+![](../images-weaver-docs/architecture-assets/relay_flow.png)
+
+1. An application sends a request to their networks relay over gRPC
+2. The local relay inspects the query within the request and uses the relevant information to forward the request to the correct remote relay
+3. The remote relay's driver interprets the query and invokes the smart contract for the query
+4. Once network B has returned a response to its relay, the relay forwards the response back to relay A
+5. The application gets the response from the relay, this can either be via a push or pull mechanism
+6. The application invokes a domain specific smart contract to process the response from network B

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -92,7 +92,12 @@ nav:
     - Architecture: architecture.md
     - Key Concepts:
       - Overview: concepts/index.md
+      - Asset Exchange: concepts/asset-exchange.md
+      - Asset Transfer: concepts/asset-transfer.md
       - Data Sharing: concepts/data-sharing.md
+      - Relay: concepts/relay.md
+      - Connector: concepts/connector.md
+      - Identity: concepts/identity.md
     - Use Cases: use-cases.md
   - Platforms:
     - Cactus:


### PR DESCRIPTION
## Description

Unified Key Concepts in main documentation by migrating from Weaver.  Concepts are: 
- Asset Transfer
- Asset Exchange
- Data Sharing
- Connector
- Relay
- Identity

They are somewhat redundant to the concepts in the glossary page.

## Related issue

Closes #4683

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
