### PR TITLE
ci: remove unnecessary git pull from docs publish

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -86,5 +86,10 @@ jobs:
         run: 'python3 docs/scripts/publish_openapi.py'
         
       - name: Build and publish
-        run: git pull && mkdocs gh-deploy
+        # NOTE: no `git pull` here. This workflow is triggered by tag pushes, so
+        # actions/checkout leaves us in detached-HEAD state; `git pull` would fail
+        # with "You are not currently on a branch". `mkdocs gh-deploy` manages the
+        # gh-pages branch on its own (force-pushes via ghp-import), so it needs no
+        # pull of the source ref.
+        run: mkdocs gh-deploy
         working-directory: docs


### PR DESCRIPTION
<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

`deploy_docs.yaml` workflow is triggered by tag pushes, so
 actions/checkout leaves us in detached-HEAD state; `git pull` would fail
 with "You are not currently on a branch". `mkdocs gh-deploy` manages the
gh-pages branch on its own (force-pushes via ghp-import), so it needs no
pull of the source ref.

## PR author checklist

- [ ] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [ ] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
