### PR TITLE
docs(packages): standardize remaining package documentation

### DIFF
--- a/docs/docs/cactus/packages.md
+++ b/docs/docs/cactus/packages.md
@@ -13,17 +13,18 @@ For detailed documentation, click the package name to view its canonical README 
 | [cactus-core-api](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-core-api) | Interfaces and abstract classes defining the Cacti plugin architecture. |
 | [cactus-api-client](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-api-client) | Default API client library for application developers interacting with Cacti. |
 | [cactus-plugin-satp-hermes](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-satp-hermes) | Secure Asset Transfer Protocol implementation for atomic asset transfers. |
-| [cactus-plugin-bungee-hermes](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-bungee-hermes) | Extension package providing Bungee routing capabilities for Hermes. |
-| [cacti-ledger-browser](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-ledger-browser) | Ledger browser utility for viewing cross-chain transactions. |
+| [cactus-plugin-bungee-hermes](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-bungee-hermes) | Creates and combines distributed-ledger views for Cacti data-sharing flows. |
+| [cacti-ledger-browser](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-ledger-browser) | React application for visualizing ledger data exposed through Cacti. |
 
 ## Connectors, Plugins, and Infrastructure
 
 | Package Name | Description |
 | :--- | :--- |
 | [cactus-cmd-api-server](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-cmd-api-server) | The centralized API server responsible for orchestrating Cacti plugins. |
-| [cacti-copm-core](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-copm-core) | Core operations and lifecycle management subsystem logic. |
-| [cacti-plugin-copm-corda](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-plugin-copm-corda) | Operations lifecycle management plugin for the Corda ledger. |
-| [cacti-plugin-copm-fabric](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-plugin-copm-fabric) | Operations lifecycle management plugin for the Hyperledger Fabric ledger. |
+| [cacti-copm-core](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-copm-core) | Common types, services, validators, and ledger abstractions for COPM. |
+| [cacti-plugin-copm-corda](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-plugin-copm-corda) | Corda implementation of COPM operations. |
+| [cacti-plugin-copm-fabric](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-plugin-copm-fabric) | Fabric implementation of COPM operations. |
+| [cacti-plugin-consortium-static](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-plugin-consortium-static) | Static consortium repository with authenticated node enrollment. |
 | [cacti-plugin-weaver-driver-fabric](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-plugin-weaver-driver-fabric) | Interoperability driver enabling Weaver functionality on Fabric. |
 | [cactus-plugin-ledger-connector-besu](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-ledger-connector-besu) | Standardized connector for interacting with Hyperledger Besu. |
 | [cactus-plugin-ledger-connector-corda](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-ledger-connector-corda) | Standardized connector for interacting with R3 Corda. |
@@ -31,8 +32,17 @@ For detailed documentation, click the package name to view its canonical README 
 | [cactus-plugin-ledger-connector-fabric](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-ledger-connector-fabric) | Standardized connector for interacting with Hyperledger Fabric. |
 | [cacti-plugin-ledger-connector-stellar](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-plugin-ledger-connector-stellar) | Standardized connector for interacting with the Stellar network. |
 | [cactus-plugin-keychain-memory](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-keychain-memory) | In-memory keychain plugin for local development and testing environments. |
+| [cactus-plugin-htlc-eth-besu](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-htlc-eth-besu) | Hash time-locked contract operations on Besu. |
+| [cactus-plugin-htlc-eth-besu-erc20](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-htlc-eth-besu-erc20) | ERC-20 hash time-locked contract operations on Besu. |
 | [cactus-plugin-persistence-ethereum](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-persistence-ethereum) | Persistence plugin for syncing Ethereum ledger state to a database. |
 | [cactus-plugin-persistence-fabric](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-persistence-fabric) | Persistence plugin for syncing Fabric ledger state to a database. |
+
+## Extensions
+
+| Package Name | Description |
+| :--- | :--- |
+| [cactus-plugin-object-store-ipfs](https://github.com/hyperledger-cacti/cacti/tree/main/extensions/cactus-plugin-object-store-ipfs) | IPFS-backed implementation of the Cacti object-store interface. |
+| [cactus-plugin-htlc-coordinator-besu](https://github.com/hyperledger-cacti/cacti/tree/main/extensions/cactus-plugin-htlc-coordinator-besu) | Coordinates Besu and Besu ERC-20 HTLC operations. |
 
 ## Test and Tooling Packages
 
@@ -42,3 +52,8 @@ For detailed documentation, click the package name to view its canonical README 
 | [cactus-test-api-client](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-test-api-client) | Testing harnesses for API client interactions. |
 | [cactus-test-cmd-api-server](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-test-cmd-api-server) | Testing harnesses for the main API server. |
 | [cacti-copm-test](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cacti-copm-test) | Testing suites specific to COPM subsystem functionality. |
+| [cactus-test-geth-ledger](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-test-geth-ledger) | Helpers for running ephemeral go-ethereum ledgers in tests. |
+| [cactus-test-plugin-htlc-eth-besu](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-test-plugin-htlc-eth-besu) | Integration tests for the Besu HTLC plugin. |
+| [cactus-test-plugin-htlc-eth-besu-erc20](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-test-plugin-htlc-eth-besu-erc20) | Integration tests for the Besu ERC-20 HTLC plugin. |
+| [cactus-test-plugin-ledger-connector-besu](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-test-plugin-ledger-connector-besu) | Integration tests for the Besu connector and API server. |
+| [cactus-test-plugin-ledger-connector-ethereum](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-test-plugin-ledger-connector-ethereum) | Integration tests for the Ethereum connector and API server. |

--- a/docs/docs/satp-hermes/api3-adapter-spec.md
+++ b/docs/docs/satp-hermes/api3-adapter-spec.md
@@ -1,0 +1,1 @@
+--8<-- "packages/cactus-plugin-satp-hermes/docs/api3-adapter-spec.md"

--- a/docs/docs/satp-hermes/architecture/satp-hermes.md
+++ b/docs/docs/satp-hermes/architecture/satp-hermes.md
@@ -1,0 +1,1 @@
+--8<-- "packages/cactus-plugin-satp-hermes/docs/architecture/satp-hermes.md"

--- a/docs/docs/satp-hermes/configuration.md
+++ b/docs/docs/satp-hermes/configuration.md
@@ -1,0 +1,1 @@
+--8<-- "packages/cactus-plugin-satp-hermes/docs/configuration.md:content"

--- a/docs/docs/satp-hermes/database.md
+++ b/docs/docs/satp-hermes/database.md
@@ -1,0 +1,1 @@
+--8<-- "packages/cactus-plugin-satp-hermes/docs/database.md:content"

--- a/docs/docs/satp-hermes/operations.md
+++ b/docs/docs/satp-hermes/operations.md
@@ -1,0 +1,1 @@
+--8<-- "packages/cactus-plugin-satp-hermes/docs/operations.md:content"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -85,108 +85,126 @@ extra:
   version:
     provider: mike
 nav:
-  - Introduction: index.md
-  - Vision: vision.md
-  - Architecture: architecture.md
-  - Key Concepts:
-    - Data Sharing: concepts/data-sharing.md
-  - Use Cases: use-cases.md
-  - Cactus:
-    - Introduction: cactus/introduction.md
-    - Building: cactus/build.md
-    - Examples:
-      - Overview: cactus/examples.md
-      - Supply Chain Application: cactus/examples/supply-chain-app.md
-    - Governance: cactus/governance.md
-    - Code of Conduct: cactus/code-of-conduct.md
-    - Contributing: cactus/contributing.md
-    - Whitepaper: cactus/whitepaper.md
-    - Regulatory and Industry Initiatives: cactus/regulatory-and-industry-initiatives-reading-list.md
-    - Packages: cactus/packages.md
-    - Ledger Browser:
-      - Overview:  cactus/ledger-browser/overview.md
-      - Setup:  cactus/ledger-browser/setup.md
-      - Plugin Apps:
-        - App Patterns:  cactus/ledger-browser/plugin-apps/app-patterns.md
-        - Ethereum Browser:  cactus/ledger-browser/plugin-apps/ethereum-browser.md
-        - Hyperledger Fabric Browser:  cactus/ledger-browser/plugin-apps/fabric-browser.md
-      - Developer Guide:
-        - Overview:  cactus/ledger-browser/developer-guide/overview.md
-        - Architecture:  cactus/ledger-browser/developer-guide/architecture.md
-        - Tutorial:  cactus/ledger-browser/developer-guide/tutorial.md
-    - Ledger Support:
-      - Overview: cactus/support.md
-      - Hyperledger Besu: cactus/support/besu.md
-      - R3 Corda: cactus/support/corda.md
-      - Hyperledger Fabric: cactus/support/fabric.md
-      - Hyperledger Iroha: cactus/support/iroha.md
-  - Weaver:
-    - Framework: weaver/introduction.md
-    - Getting Started:
-      - Using Weaver: weaver/getting-started/guide.md
-      - Launching a Test Network:
-        - Component Overview: weaver/getting-started/test-network/overview.md
-        - Setup with Locally Built Weaver Components: weaver/getting-started/test-network/setup-local.md
-        - Setup with Locally Built Dockerized Weaver Components: weaver/getting-started/test-network/setup-local-docker.md
-        - Setup with Imported Weaver Components: weaver/getting-started/test-network/setup-packages.md
-        - Setup with Imported Dockerized Weaver Components: weaver/getting-started/test-network/setup-packages-docker.md
-        - Ledger Initialization: weaver/getting-started/test-network/ledger-initialization.md
-        - Advanced Configuration: weaver/getting-started/test-network/advanced-configuration.md
-      - Testing Interoperation Modes:
-        - Overview: weaver/getting-started/interop/overview.md
-        - Data Sharing: weaver/getting-started/interop/data-sharing.md
-        - Asset Exchange:
-          - Overview: weaver/getting-started/interop/asset-exchange/overview.md
-          - Fabric with Fabric: weaver/getting-started/interop/asset-exchange/fabric-fabric.md
-          - Fabric with Corda: weaver/getting-started/interop/asset-exchange/fabric-corda.md
-          - Fabric with Besu: weaver/getting-started/interop/asset-exchange/fabric-besu.md
-          - Corda with Corda: weaver/getting-started/interop/asset-exchange/corda-corda.md
-          - Corda with Besu: weaver/getting-started/interop/asset-exchange/corda-besu.md
-          - Besu with Besu: weaver/getting-started/interop/asset-exchange/besu-besu.md
-        - Asset Transfer: weaver/getting-started/interop/asset-transfer.md
-      - Enabling Weaver in your Network and Application:
-        - Overview: weaver/getting-started/enabling-weaver-network/overview.md
-        - Hyperledger Fabric: weaver/getting-started/enabling-weaver-network/fabric.md
-        - R3 Corda: weaver/getting-started/enabling-weaver-network/corda.md
-        - Hyperledger Besu: weaver/getting-started/enabling-weaver-network/besu.md
-    - What is Interoperability?:
-      - Understanding Interoperability: weaver/what-is-interoperability/understanding-interoperability.md
-      - Levels of Interoperability: weaver/what-is-interoperability/levels-of-interoperability.md
-      - Integration Patterns: weaver/what-is-interoperability/integration-patterns.md
-    - Interoperability Modes: weaver/interoperability-modes.md
-    - Design Principles: weaver/design-principles.md
-    - User Stories:
-      - Overview: weaver/user-stories/overview.md
-      - Global Trade: weaver/user-stories/global-trade.md
-      - DvP in Financial Markets: weaver/user-stories/financial-markets.md
-      - Legacy Integration: weaver/user-stories/legacy-integration.md
-    - Architecture and Design:
-      - Overview: weaver/architecture-and-design/overview.md
-      - Relay: weaver/architecture-and-design/relay.md
-      - Drivers: weaver/architecture-and-design/drivers.md
-      - Weaver DApps: weaver/architecture-and-design/weaver-dapps.md
-      - Decentralized Identity: weaver/architecture-and-design/decentralized-identity.md
-    - Security Model:
-      - Authentication: weaver/security-model/authentication.md
-      - Access Control: weaver/security-model/access-control.md
-      - Proofs and Verification: weaver/security-model/proofs-and-verification.md
-      - End-to-End Security: weaver/security-model/end-to-end-security.md
-    - Deployment Considerations:
-      - Deployment Patterns: weaver/deployment-considerations/deployment-patterns.md
-      - Governance and Policies: weaver/deployment-considerations/governance-and-policies.md
-      - Legal and Regulation: weaver/deployment-considerations/legal-and-regulation.md
-    - Specifications: weaver/specifications.md
-    - Roadmap: weaver/roadmap.md
-    - Publications: weaver/publications.md
-  - SATP Hermes:
-    - Architecture: satp-hermes/architecture/satp-hermes.md
-  - Guides:
-    - Getting Started: guides/getting-started.md
-    - Nix Setup: guides/nix-setup.md
-    - Operations: guides/operations.md
-    - Developers: guides/developers.md
-    - Upgrading: guides/upgrading.md
-  - References:
+  - Overview:
+    - Introduction: index.md
+    - Start Here: start-here.md
+    - Vision: vision.md
+    - Architecture: architecture.md
+    - Key Concepts:
+      - Overview: concepts/index.md
+      - Data Sharing: concepts/data-sharing.md
+    - Use Cases: use-cases.md
+  - Platforms:
+    - Cactus:
+      - Introduction: cactus/introduction.md
+      - Building: cactus/build.md
+      - Examples:
+        - Overview: cactus/examples.md
+        - Supply Chain Application: cactus/examples/supply-chain-app.md
+      - Governance: cactus/governance.md
+      - Code of Conduct: cactus/code-of-conduct.md
+      - Contributing: cactus/contributing.md
+      - Whitepaper: cactus/whitepaper.md
+      - Regulatory and Industry Initiatives: cactus/regulatory-and-industry-initiatives-reading-list.md
+      - Packages: cactus/packages.md
+      - Ledger Browser:
+        - Overview: cactus/ledger-browser/overview.md
+        - Setup: cactus/ledger-browser/setup.md
+        - Plugin Apps:
+          - App Patterns: cactus/ledger-browser/plugin-apps/app-patterns.md
+          - Ethereum Browser: cactus/ledger-browser/plugin-apps/ethereum-browser.md
+          - Hyperledger Fabric Browser: cactus/ledger-browser/plugin-apps/fabric-browser.md
+        - Developer Guide:
+          - Overview: cactus/ledger-browser/developer-guide/overview.md
+          - Architecture: cactus/ledger-browser/developer-guide/architecture.md
+          - Tutorial: cactus/ledger-browser/developer-guide/tutorial.md
+      - Ledger Support:
+        - Overview: cactus/support.md
+        - Hyperledger Besu: cactus/support/besu.md
+        - R3 Corda: cactus/support/corda.md
+        - Hyperledger Fabric: cactus/support/fabric.md
+        - Hyperledger Iroha: cactus/support/iroha.md
+    - Weaver:
+      - Framework: weaver/introduction.md
+      - Getting Started:
+        - Using Weaver: weaver/getting-started/guide.md
+        - Launching a Test Network:
+          - Component Overview: weaver/getting-started/test-network/overview.md
+          - Setup with Locally Built Weaver Components: weaver/getting-started/test-network/setup-local.md
+          - Setup with Locally Built Dockerized Weaver Components: weaver/getting-started/test-network/setup-local-docker.md
+          - Setup with Imported Weaver Components: weaver/getting-started/test-network/setup-packages.md
+          - Setup with Imported Dockerized Weaver Components: weaver/getting-started/test-network/setup-packages-docker.md
+          - Ledger Initialization: weaver/getting-started/test-network/ledger-initialization.md
+          - Advanced Configuration: weaver/getting-started/test-network/advanced-configuration.md
+        - Testing Interoperation Modes:
+          - Overview: weaver/getting-started/interop/overview.md
+          - Data Sharing: weaver/getting-started/interop/data-sharing.md
+          - Asset Exchange:
+            - Overview: weaver/getting-started/interop/asset-exchange/overview.md
+            - Fabric with Fabric: weaver/getting-started/interop/asset-exchange/fabric-fabric.md
+            - Fabric with Corda: weaver/getting-started/interop/asset-exchange/fabric-corda.md
+            - Fabric with Besu: weaver/getting-started/interop/asset-exchange/fabric-besu.md
+            - Corda with Corda: weaver/getting-started/interop/asset-exchange/corda-corda.md
+            - Corda with Besu: weaver/getting-started/interop/asset-exchange/corda-besu.md
+            - Besu with Besu: weaver/getting-started/interop/asset-exchange/besu-besu.md
+          - Asset Transfer: weaver/getting-started/interop/asset-transfer.md
+        - Enabling Weaver in your Network and Application:
+          - Overview: weaver/getting-started/enabling-weaver-network/overview.md
+          - Hyperledger Fabric: weaver/getting-started/enabling-weaver-network/fabric.md
+          - R3 Corda: weaver/getting-started/enabling-weaver-network/corda.md
+          - Hyperledger Besu: weaver/getting-started/enabling-weaver-network/besu.md
+      - What is Interoperability?:
+        - Understanding Interoperability: weaver/what-is-interoperability/understanding-interoperability.md
+        - Levels of Interoperability: weaver/what-is-interoperability/levels-of-interoperability.md
+        - Integration Patterns: weaver/what-is-interoperability/integration-patterns.md
+      - Interoperability Modes: weaver/interoperability-modes.md
+      - Design Principles: weaver/design-principles.md
+      - User Stories:
+        - Overview: weaver/user-stories/overview.md
+        - Global Trade: weaver/user-stories/global-trade.md
+        - DvP in Financial Markets: weaver/user-stories/financial-markets.md
+        - Legacy Integration: weaver/user-stories/legacy-integration.md
+      - Architecture and Design:
+        - Overview: weaver/architecture-and-design/overview.md
+        - Relay: weaver/architecture-and-design/relay.md
+        - Drivers: weaver/architecture-and-design/drivers.md
+        - Weaver DApps: weaver/architecture-and-design/weaver-dapps.md
+        - Decentralized Identity: weaver/architecture-and-design/decentralized-identity.md
+      - Security Model:
+        - Authentication: weaver/security-model/authentication.md
+        - Access Control: weaver/security-model/access-control.md
+        - Proofs and Verification: weaver/security-model/proofs-and-verification.md
+        - End-to-End Security: weaver/security-model/end-to-end-security.md
+      - Deployment Considerations:
+        - Deployment Patterns: weaver/deployment-considerations/deployment-patterns.md
+        - Governance and Policies: weaver/deployment-considerations/governance-and-policies.md
+        - Legal and Regulation: weaver/deployment-considerations/legal-and-regulation.md
+      - Specifications: weaver/specifications.md
+      - Roadmap: weaver/roadmap.md
+      - Publications: weaver/publications.md
+    - SATP Hermes:
+      - Architecture: satp-hermes/architecture/satp-hermes.md
+      - Gateway Configuration: satp-hermes/configuration.md
+      - API Type 3 Adapter Specification: satp-hermes/api3-adapter-spec.md
+      - Database and Migrations: satp-hermes/database.md
+      - Operations: satp-hermes/operations.md
+  - Build and Operate:
+    - Guides:
+      - Getting Started: guides/getting-started.md
+      - Nix Setup: guides/nix-setup.md
+      - Operations: guides/operations.md
+      - Developers: guides/developers.md
+      - Upgrading: guides/upgrading.md
+    - Recipes:
+      - Overview: recipes/index.md
+      - Git Branch Setup: recipes/git-branch-setup.md
+      - Create a New Package: recipes/create-new-package.md
+      - Testing Guide: recipes/testing-guide.md
+      - Ledger Plugin Testing: recipes/ledger-plugin-testing.md
+      - Building API Clients: recipes/building-api-clients.md
+      - Managing Dependencies: recipes/managing-dependencies.md
+      - VS Code Setup: recipes/vscode-setup.md
+  - Reference:
     - Technical Specifications: references/specs.md
     - Publications: references/publications.md
     - Events and Podcasts: references/events.md

--- a/extensions/cactus-plugin-htlc-coordinator-besu/README.md
+++ b/extensions/cactus-plugin-htlc-coordinator-besu/README.md
@@ -1,8 +1,40 @@
-# `@hyperledger/cactus-plugin-htlc-coordinator-besu`
+# `@hyperledger-cacti/cactus-plugin-htlc-coordinator-besu`
 
-Allows Cactus nodes to interact beetwen diferent networks. Using this we can perform:
-* Instantiate an existing HTLC plugin, also the own HTLC and the counterparty HTLC.
-* Interact with the HTLC, deploying, checking and withdrawing the funds.
+## Overview
+
+This extension coordinates hash time-locked contract (HTLC) operations through
+the Besu and Besu ERC-20 HTLC plugins. It locates the required connector and
+HTLC plugins in a Cacti `PluginRegistry`, then exposes operations for creating
+the initiating and counterparty contracts and withdrawing counterparty funds.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-htlc-coordinator-besu
+```
+
+## Configuration
+
+The `IPluginHTLCCoordinatorBesuOptions` interface accepts:
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `instanceId` | Yes | None | Unique identifier for the coordinator instance. |
+| `pluginRegistry` | Yes | None | Registry containing the Besu connector and HTLC plugins used by requests. |
+| `logLevel` | No | `"INFO"` | Coordinator log level. |
+
+## API Summary
+
+The coordinator exposes `ownHTLC`, `counterpartyHTLC`, and
+`withdrawCounterparty` operations through both its TypeScript API and OpenAPI
+web services. Request and response schemas are defined in the
+[OpenAPI specification](./src/main/json/openapi.json).
+
 ## Summary
 
   - [Usage](#usage)
@@ -15,7 +47,9 @@ Allows Cactus nodes to interact beetwen diferent networks. Using this we can per
 
 ## Usage
 
-To use this import public-api and create new **PluginFactoryHTLCCoordinatorBesu*. Then use it to create a HTLC Coordinator.
+Import the public API and use `PluginFactoryHTLCCoordinatorBesu` to create a
+coordinator:
+
 ```typescript
     const factoryHTLC = new PluginFactoryHTLCCoordinatorBesu({
         pluginImportType: PluginImportType.Local,
@@ -48,7 +82,7 @@ Call example to create an ownHTLC and instantiate a HTLC contract:
         outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
         gas: estimatedGas,
     };
-    const response = await coordinator.ownCoordinator(ownHTLCRequest);
+    const response = await pluginHTLCCoordinatorBesu.ownHTLC(ownHTLCRequest);
 });
 ```
 The field "htlcPackage" can have the following values:
@@ -84,19 +118,26 @@ yarn run watch
 
 #### Alice flow
 
-The [Alice diagram](docs/flow/htlc-coordinator-alice-flow.md, "Alice Flow") shows the sequence diagram of a complete flow for a participant who wants exchange funds with another participant. She doesn't start the withdraw flow becuase she doesn't know the secret to withdraw them.
+The [Alice diagram](./docs/flow/htlc-coordinator-alice-flow.md) shows the
+sequence for a participant who initiates an exchange but does not know the
+secret required to withdraw the counterparty funds.
 
 #### Bob flow
 
-The next [Bob diagram](docs/flow/htlc-coordinator-bob-flow.md, "Bob Flow") 
-shows the sequence diagram of a complete flow for a participant who wants exchange funds with another participant, but he knows the secret and starts the flow to withdraw the funds.
+The [Bob diagram](./docs/flow/htlc-coordinator-bob-flow.md) shows the sequence
+for a participant who knows the secret and initiates withdrawal.
 
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript
+```
 
 ## Contributing
 
-We welcome contributions to Hyperledger Cactus in many forms, and there’s always plenty to do!
-
-Please review [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
 
 ## License
 

--- a/extensions/cactus-plugin-object-store-ipfs/README.md
+++ b/extensions/cactus-plugin-object-store-ipfs/README.md
@@ -1,9 +1,27 @@
-# `@hyperledger/cactus-plugin-object-store-ipfs`
+# `@hyperledger-cacti/cactus-plugin-object-store-ipfs`
 
-This plugin provides `Cactus` a way to interact with IPFS networks. Using this we can perform:
+## Overview
+
+This plugin provides Cacti with an IPFS-backed implementation of the object
+store plugin interface. It can:
+
 - Insert objects in the IPFS network.
 - Retrieve objects from the IPFS network.
 - Check existence of an object in the IPFS network.
+
+The plugin namespaces stored objects under a configured parent directory and
+accepts either Kubo RPC client options or an initialized compatible client.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-object-store-ipfs
+```
 
 ## Summary
 
@@ -21,23 +39,44 @@ your local machine for development and testing purposes.
 
 ### Prerequisites
 
-In the root of the project to install the dependencies execute the command:
+From the repository root, install dependencies and build the project:
+
 ```sh
-npm run configure
+yarn run configure
 ```
 
 ### Compiling
 
-In the project root folder, run this command to compile the plugin and create the dist directory:
+Compile the TypeScript project from the repository root:
+
 ```sh
-npm run tsc
+yarn run tsc
 ```
 
 ## Architecture
 
->TODO
+The plugin implements `IPluginObjectStore` and uses `kubo-rpc-client` to
+communicate with an IPFS node. The `parentDir` option provides a namespace for
+all keys handled by a plugin instance. Web service endpoints delegate to the
+same `get`, `has`, and `set` operations exposed by the plugin class.
+
+## Configuration
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `instanceId` | Yes | None | Unique identifier for the plugin instance. |
+| `parentDir` | Yes | None | IPFS directory used to namespace object keys. |
+| `ipfsClientOrOptions` | Yes | None | Kubo RPC client options or a compatible initialized client. |
+| `logLevel` | No | `"INFO"` | Plugin log level. |
+
+## API Summary
+
 ### API Endpoints
-This plugin uses OpenAPI to generate the API paths. There are three endpoints defined for each operation supported (get, set, has).
+
+The plugin defines OpenAPI endpoints for the three supported object-store
+operations: `get`, `has`, and `set`. See the
+[OpenAPI specification](./src/main/json/openapi.json) for request and response
+schemas.
 
 ## Usage
 
@@ -96,12 +135,21 @@ const isPresent = response.data.isPresent;
 const timestamp = response.data.checkedAt;
 ```
 
-## Contributing
-We welcome contributions to Hyperledger Cactus in many forms, and there’s always plenty to do!
+## Testing
 
-Please review [CONTRIBUTING.md](https://github.com/hyperledger/cactus/blob/main/CONTRIBUTING.md "CONTRIBUTING.md") to get started.
+From the repository root, run the tracked package tests with:
+
+```sh
+yarn test:jest:all extensions/cactus-plugin-object-store-ipfs/src/test/typescript
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
 
 ## License
-This distribution is published under the Apache License Version 2.0 found in the [LICENSE ](https://github.com/hyperledger/cactus/blob/main/LICENSE "LICENSE ")file.
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.
 
 ## Acknowledgments

--- a/packages/cacti-copm-core/README.md
+++ b/packages/cacti-copm-core/README.md
@@ -1,3 +1,4 @@
+# `@hyperledger-cacti/cacti-copm-core`
 
 - [Overview](#overview)
 - [Usage](#usage)
@@ -13,27 +14,37 @@
     - [Figure: Asset Exchange with Lock and ClaimLock](#figure-asset-exchange-with-lock-and-claimlock)
 - [Development](#development)
 
-# Overview
+## Overview
 
 This package defines the common types, interfaces, and endpoints for the
-COPM module to be used by Digital Ledger-specific implementations.
+COPM module to be used by distributed-ledger-specific implementations.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
 
 These endpoints require specific chaincode and weaver relays to be deployed on the network.
 Please refer to [the Weaver documentation](https://hyperledger-cacti.github.io/cacti/weaver/introduction/).
 
+## Install
 
-# Usage
+```sh
+npm install @hyperledger-cacti/cacti-copm-core
+```
+
+## API Summary
+
+The package exports the ConnectRPC `DefaultService`, generated request and
+response types, common ledger and relay types, COPM interfaces, validators,
+`ViewAddress`, and `TransferrableAsset`. For the complete RPC contract, see
+the [COPM OpenAPI reference](https://hyperledger-cacti.github.io/cacti/references/openapi/cacti-copm-core_openapi/).
+
+## Usage
 
 For a detailed command specification, please refer to the [OpenAPI Endpoint Documentation](https://hyperledger-cacti.github.io/cacti/references/openapi/cacti-copm-core_openapi/)
 
-## Installation
-
-Yarn: 
-
-    yarn add --exact @hyperledger-cacti/cacti-copm-core
-
-
-## Data Sharing
+### Data Sharing
  - ability to read data on another network
  - the other network must first give you permission
   
@@ -75,7 +86,7 @@ sequenceDiagram
     deactivate COPM gRPC A
 ```
 
-## Asset Transfer
+### Asset Transfer
 
  - Asset changes networks
  - Asset burnt on Ledger A, minted on Ledger B
@@ -125,7 +136,7 @@ sequenceDiagram
     deactivate System B
 ```
 
-## Asset Exchange
+### Asset Exchange
 
  - Assets stay where they are
  - Two parties swap asset ownership of two assets
@@ -175,10 +186,26 @@ sequenceDiagram
 ```
 
 
-# Development
+## Development
 
 When implementing a new distributed ledger, the following interfaces must be implemented:
 
 - DLTransactionContext:  Implements running a transaction on the local network
 - DLRemoteTransactionContext: Uses the weaver relays to run a transaction on another network
 - DLTransactionContextFactory: Factory to return either local or remote context for the specific DLT.
+
+## Testing
+
+This package does not define a package-local test script. Its generated service
+contract and shared abstractions are exercised by the ledger-specific COPM
+plugins and the integration tests in
+[`cacti-copm-test`](../cacti-copm-test/README.md).
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.

--- a/packages/cacti-copm-test/README.md
+++ b/packages/cacti-copm-test/README.md
@@ -1,6 +1,35 @@
-# @hyperledger-cacti/cacti-copm-test
+# `@hyperledger-cacti/cacti-copm-test`
+
+## Overview
 
 Test framework for testing the COPM distributed ledger-specific plugins.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+```sh
+npm install --save-dev @hyperledger-cacti/cacti-copm-test
+```
+
+## Configuration
+
+Ledger-specific test support implements the `TestAssets` and `CopmTester`
+interfaces exported by this package. The tester factory selects the
+implementation for each supported network type.
+
+## API Summary
+
+The package exports:
+
+- `WeaverInteropConfiguration` for Weaver interoperability settings
+- `TestAssets` for issuing and inspecting test assets
+- `CopmTester` for creating a ledger-specific COPM test environment and client
+
+## Usage
 
 ## Development
 
@@ -35,4 +64,25 @@ Makefile_\<ledger_type\> will build a docker weaver network of the given network
   
 The asset exchanges and asset transfer network modes are currently mutually exclusive.
 
+## Testing
+
+The package defines separate integration-test commands for each COPM operation:
+
+```sh
+yarn workspace @hyperledger-cacti/cacti-copm-test test:view
+yarn workspace @hyperledger-cacti/cacti-copm-test test:pledge
+yarn workspace @hyperledger-cacti/cacti-copm-test test:lock
+```
+
+These tests require their corresponding ledger and Weaver test-network
+components.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.
 

--- a/packages/cacti-ledger-browser/README.md
+++ b/packages/cacti-ledger-browser/README.md
@@ -1,4 +1,23 @@
-# `@hyperledger/cacti-ledger-browser`
+# `@hyperledger-cacti/cacti-ledger-browser`
+
+## Overview
+
+This package provides the React-based Cacti Ledger Browser for visualizing ledger data exposed through Cacti services.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cacti-ledger-browser
+```
+
+## API Summary
+
+The package is a browser application rather than a reusable plugin API. Its source is organized under [`src/`](./src/), with runtime configuration supplied when the application is built and deployed.
 
 This component allows viewing ledger data in Supabase or other PostgreSQL compatible database. The data is fed to supabase by persistence plugins for each ledgers.
 
@@ -34,3 +53,15 @@ Please review [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 This distribution is published under the Apache License Version 2.0 found in the [LICENSE](../../LICENSE) file.
 
 ## Acknowledgments
+
+## Usage
+
+Configure the application for the target Cacti API and run it through the monorepo development workflow described below.
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cacti-ledger-browser/src/test
+```

--- a/packages/cacti-plugin-consortium-static/README.md
+++ b/packages/cacti-plugin-consortium-static/README.md
@@ -1,5 +1,32 @@
 # `@hyperledger-cacti/cacti-plugin-consortium-static`
 
+## Overview
+
+This plugin provides a static consortium repository with authenticated node enrollment, shared consortium metadata, and an experimental policy model. It does not implement consensus or reliable broadcast between consortium nodes.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cacti-plugin-consortium-static
+```
+
+## Configuration
+
+Configure the local node, member identity, ledgers, plugin instances, organization public keys, consortium nodes, shared package configuration, and optional root policy group through `IPluginConsortiumStaticOptions`.
+
+## API Summary
+
+The public API exports `PluginConsortiumStatic`, its factory and options, `StaticConsortiumProvider`, generated OpenAPI client types, consortium endpoints, policy-model types, token utilities, and Prometheus metric names. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
+
+## Usage
+
+The integration tests under [`src/test/typescript/integration/`](./src/test/typescript/integration/) demonstrate plugin construction, authenticated node enrollment, and repository updates.
+
 ## Cacti Consortium Static
 
 This plugin is an improvement of the package /cactus-plugin-consortium-manual ,bringing some new features to the table while conserving the possibility to be used as the old one (not allowing runtime changes)
@@ -52,3 +79,20 @@ The model is in an early stage, and serves only as a POC for now. The goal is to
 ## Notes
 
 For usage, check the tests in the /integration folder
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cacti-plugin-consortium-static/src/test/typescript
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.

--- a/packages/cacti-plugin-copm-corda/README.md
+++ b/packages/cacti-plugin-copm-corda/README.md
@@ -1,6 +1,13 @@
-# @hyperledger-cacti/cacti-plugin-copm-corda
+# `@hyperledger-cacti/cacti-plugin-copm-corda`
+
+## Overview
 
 Implements COPM primitives for Corda as a cacti plugin.  The implementation follows the model of the Corda ledger connector plugin, where a typescript pass-through implementation is registered on the plugin server, and commands are implemented on a separate grpc server in the Kotlin Spring framework.  
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
 
 Command documentation as OpenAPI:
 https://hyperledger-cacti.github.io/cacti/references/openapi/cacti-copm-core_openapi/
@@ -16,18 +23,38 @@ These endpoints require the following:
   
 Please see https://hyperledger-cacti.github.io/cacti/weaver/introduction/.
 
-# Usage
+## Install
 
-## Installation
+```sh
+npm install @hyperledger-cacti/cacti-plugin-copm-corda
+```
 
-Yarn: 
+## Configuration
 
-    yarn add --exact @hyperledger-cacti/cacti-plugin-copm-corda
+The TypeScript plugin accepts the following constructor options:
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `instanceId` | Yes | None | Unique identifier for the plugin instance. |
+| `copmKotlinServerBaseUrl` | Yes | None | Base URL of the Kotlin ConnectRPC server. |
+| `logLevel` | No | `"INFO"` | Plugin log level. |
+
+The Kotlin service requires application-specific implementations of
+`CordaConfiguration` and `InteropConfiguration`. Register those
+implementations as Spring components, as demonstrated by the test application.
+
+## API Summary
+
+The plugin registers the COPM `DefaultService` ConnectRPC contract from
+`@hyperledger-cacti/cacti-copm-core` and forwards calls to the configured
+Kotlin server. See the [COPM OpenAPI reference](https://hyperledger-cacti.github.io/cacti/references/openapi/cacti-copm-core_openapi/).
+
+## Usage
 
 In a production scenario the kotlin server should be deployed and reachable from the cacti server plugin. Please see
 the Dockerfile in src/test as an example.
 
-## Configuration
+### Kotlin service configuration
 
 The following application-specific interfaces must be implemented:
 
@@ -38,5 +65,21 @@ These implementations should be marked as Spring components, as shown in the exa
 
 ## Development
 
-Please see [the cacti-cop-test README](./../cacti-copm-test/README.md) for details on building a 
-corda test network.
+See the [cacti-copm-test README](../cacti-copm-test/README.md) for details on
+building a Corda test network.
+
+## Testing
+
+The package does not define a standalone test command. Its sample Kotlin server
+and Corda integration are exercised through the
+[`cacti-copm-test`](../cacti-copm-test/README.md) network and integration
+suite.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.

--- a/packages/cacti-plugin-copm-fabric/README.md
+++ b/packages/cacti-plugin-copm-fabric/README.md
@@ -1,6 +1,13 @@
-# @hyperledger-cacti/cacti-plugin-copm-fabric
+# `@hyperledger-cacti/cacti-plugin-copm-fabric`
+
+## Overview
 
 This cactus plugin implements a connectRPC server for the fabric COPM implementation.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
 
 Command documentation as OpenAPI:
 https://hyperledger-cacti.github.io/cacti/references/openapi/cacti-copm-core_openapi/
@@ -12,17 +19,22 @@ These endpoints require the following:
   
 Please see https://hyperledger-cacti.github.io/cacti/weaver/introduction/.
 
+## Install
 
-# Usage
-
-## Installation
-
-Yarn: 
-
-    yarn add --exact @hyperledger-cacti/cacti-plugin-copm-fabric
-
+```sh
+npm install @hyperledger-cacti/cacti-plugin-copm-fabric
+```
 
 ## Configuration
+
+The `IPluginCopmFabricOptions` interface accepts:
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `instanceId` | Yes | None | Unique identifier for the plugin instance. |
+| `fabricConfig` | Yes | None | Fabric connection, wallet, contract, and asset-contract configuration. |
+| `interopConfig` | Yes | None | Local relay and remote organization configuration. |
+| `logLevel` | No | `"INFO"` | Plugin log level. |
 
 The following application-specific interfaces must be implemented:
 
@@ -39,10 +51,37 @@ The following application-specific interfaces must be implemented:
 
   These implementations are then supplied to the plugin constructor. 
 
+## API Summary
+
+The plugin implements `IPluginCrpcService` and registers the COPM
+`DefaultService` from `@hyperledger-cacti/cacti-copm-core`. Its public API
+also exports `PluginCopmFabric`, `FabricConfiguration`,
+`FabricTransactionContextFactory`, and `FabricContractContext`.
+
+## Usage
+
+Create `FabricConfiguration` and COPM `InteropConfiguration`
+implementations for the target network, then provide them to
+`PluginCopmFabric` with a unique `instanceId`.
+
 ## Development
 
-Please see [the cacti-cop-test README](./../cacti-copm-test/README.md) for details on building a 
-fabric test network.
+See the [cacti-copm-test README](../cacti-copm-test/README.md) for details on
+building a Fabric test network.
 
-  
+## Testing
+
+The package does not define a standalone test command. Its Fabric
+implementation is exercised through the
+[`cacti-copm-test`](../cacti-copm-test/README.md) network and integration
+suite.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.
   

--- a/packages/cactus-api-client/README.md
+++ b/packages/cactus-api-client/README.md
@@ -1,4 +1,23 @@
-# `@hyperledger/cactus-api-client` <!-- omit in toc -->
+# `@hyperledger-cacti/cactus-api-client` <!-- omit in toc -->
+
+## Overview
+
+This package provides the universal Cacti API client used by browser and server applications to communicate with Cacti nodes and consortium services.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-api-client
+```
+
+## API Summary
+
+The public API exports the Cacti API client, consortium providers, generated API types, and supporting client utilities. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
 
 - [Summary](#summary)
 - [Usage](#usage)
@@ -147,3 +166,11 @@ One such common trait is the client side component of the routing that decides w
 @see — https ://github.com/OpenAPITools/openapi-generator/blob/v5.0.0-beta2/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache#L337
 
 @see — https ://github.com/OpenAPITools/openapi-generator/blob/v5.0.0/docs/generators/typescript-axios.md
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cactus-api-client/src/test/typescript
+```

--- a/packages/cactus-plugin-bungee-hermes/README.md
+++ b/packages/cactus-plugin-bungee-hermes/README.md
@@ -1,4 +1,23 @@
-# `@hyperledger/cactus-plugin-bungee-hermes`
+# `@hyperledger-cacti/cactus-plugin-bungee-hermes`
+
+## Overview
+
+This plugin creates and combines distributed-ledger views through configured Cacti ledger connectors. It implements the BUNGEE data-sharing model used by Cacti interoperability flows.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-bungee-hermes
+```
+
+## API Summary
+
+The public API exports the plugin, factory, generated OpenAPI client, privacy and merge policy types, and view creation utilities. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
 
 The package provides `Hyperledger Cacti` a way to create blockchain snapshots and views for different distributed ledgers currently supported by Cacti. The implementation follows the paper [BUNGEE](https://dl.acm.org/doi/pdf/10.1145/3643689) (Blockchain UNifier view GEnErator).
 
@@ -76,7 +95,7 @@ Endpoints exposed:
   - ProcessViewV1
 
 
-## Running the tests
+## Testing
   - **besu-test-basic.test.ts**: A test using strategy-besu and a besu connector, testing creating views for different timeframes and states.
   - **ethereum-test-basic.test.ts**: A test using strategy-ethereum and a ethereum connector, testing creating views for different timeframes and states.
   - **fabric-test-basic.test.ts**: A test using strategy-fabric and a fabric connector, testing creating views for different timeframes and states.

--- a/packages/cactus-plugin-htlc-eth-besu-erc20/README.md
+++ b/packages/cactus-plugin-htlc-eth-besu-erc20/README.md
@@ -1,4 +1,23 @@
-# `@hyperledger/cactus-plugin-htlc-eth-besu-erc20`
+# `@hyperledger-cacti/cactus-plugin-htlc-eth-besu-erc20`
+
+## Overview
+
+This plugin deploys and operates ERC-20 hash time-locked contracts on Besu through a registered Cacti Besu ledger connector.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-htlc-eth-besu-erc20
+```
+
+## API Summary
+
+The public API exports the ERC-20 HTLC plugin, its factory and options, generated OpenAPI client types, and contract artifacts. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
 
 Allows Cactus nodes to interact with HTLC contracts with ERC-20 Tokens
 
@@ -11,7 +30,7 @@ Allows Cactus nodes to interact with HTLC contracts with ERC-20 Tokens
   - [Contributing](#contributing)
   - [License](#license)
 
-## Getting Started
+## Usage
 
 ### Installing
 
@@ -21,7 +40,7 @@ In a Cactus root directory, need execute:
 ```
 This command compile and build the project.
 
-## Running the tests
+## Testing
 
 For test all the plugin we have @hyperledger/cactus-test-plugin-htlc-eth-besu-erc20
 For execute the test plugin, can execute in root directory: 

--- a/packages/cactus-plugin-htlc-eth-besu/README.md
+++ b/packages/cactus-plugin-htlc-eth-besu/README.md
@@ -1,4 +1,23 @@
-# @hyperledger/cactus-plugin-htlc-eth-besu
+# `@hyperledger-cacti/cactus-plugin-htlc-eth-besu`
+
+## Overview
+
+This plugin deploys and operates hash time-locked contracts on Besu through a registered Cacti Besu ledger connector.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-htlc-eth-besu
+```
+
+## API Summary
+
+The public API exports the HTLC plugin, its factory and options, generated OpenAPI client types, and contract artifacts. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
 
 Allows `Cacti` to interact with HTLC contract manager. 
 
@@ -12,7 +31,7 @@ Allows `Cacti` to interact with HTLC contract manager.
   - [License](#license)
 
 
-## Getting Started
+## Usage
 The smart contracts and rationalle ane explained in detail in <a href=https://medium.com/@rafaelbelchior/dlt-interoperability-and-more-%EF%B8%8F-24-privacy-preserving-cross-chain-atomic-swaps-bonus-lets-ff99a90714de> this Medium article </a>.
 
 These instructions will get you a copy of the project up and running on
@@ -26,7 +45,7 @@ Steps to compile the project: `forge build`.
 
 
 
-## Running the tests
+## Testing
 
 The tests can be found in @hyperledger/cactus-test-htlc-eth-besu. To run this, in the root project execute:
 

--- a/packages/cactus-plugin-keychain-memory/README.md
+++ b/packages/cactus-plugin-keychain-memory/README.md
@@ -1,4 +1,75 @@
-# `@hyperledger/cactus-plugin-keychain-memory`
+# `@hyperledger-cacti/cactus-plugin-keychain-memory`
+
+> In-memory keychain plugin for development and testing.
+
+## Overview
+
+This package implements the Cacti keychain plugin interfaces with a `Map`-backed
+store. It supports direct plugin calls, OpenAPI web services, and ConnectRPC
+services for setting, retrieving, checking, and deleting keychain entries.
+
+The plugin stores values as plain text and provides no encryption or persistent
+storage. Do not use it to hold production secrets.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-keychain-memory
+```
+
+## Configuration
+
+The `IPluginKeychainMemoryOptions` interface accepts the following options:
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `instanceId` | Yes | None | Unique identifier for this plugin instance. |
+| `keychainId` | Yes | None | Logical identifier for the keychain. |
+| `logLevel` | No | `"INFO"` | Plugin log level. |
+| `backend` | No | New empty `Map` | Initial in-memory key-value store. |
+| `prometheusExporter` | No | New exporter instance | Prometheus exporter used by the plugin. |
+| `observabilityBufferSize` | No | `1` | Replay buffer size for keychain operation events. |
+| `observabilityTtlSeconds` | No | `1` | Replay window for keychain operation events. |
+
+## API Summary
+
+The plugin implements `IPluginKeychain`, `IPluginWebService`, and
+`IPluginCrpcService`. Its primary operations are:
+
+- `set()` to store a value under a key
+- `get()` to retrieve a value
+- `has()` to check whether a key exists
+- `delete()` to remove a key
+- `getPrometheusMetricsV1()` to retrieve Prometheus metrics
+
+The HTTP API is defined in the
+[OpenAPI specification](./src/main/json/openapi.json). Generated TypeScript
+Axios client code is available under
+[`src/main/typescript/generated/openapi/typescript-axios/`](./src/main/typescript/generated/openapi/typescript-axios/).
+
+## Usage
+
+```typescript
+import { PluginKeychainMemory } from "@hyperledger-cacti/cactus-plugin-keychain-memory";
+
+const keychain = new PluginKeychainMemory({
+  instanceId: "keychain-memory-instance",
+  keychainId: "development-keychain",
+  logLevel: "INFO",
+});
+
+await keychain.set("example-key", "example-value");
+
+const value = await keychain.get("example-key");
+const isPresent = await keychain.has("example-key");
+
+await keychain.delete("example-key");
+```
 
 ## Prometheus Exporter
 
@@ -39,3 +110,23 @@ This file contains functions encasing the logic to process the data points
 
 ###### metrics.ts
 This file lists all the prometheus metrics and what they are used for.
+
+## Testing
+
+From the repository root, run the package tests with:
+
+```sh
+yarn test:jest:all packages/cactus-plugin-keychain-memory/src/test/typescript
+```
+
+The test suite covers the direct plugin API, generated API client, API surface,
+and observability behavior.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.

--- a/packages/cactus-plugin-persistence-ethereum/README.md
+++ b/packages/cactus-plugin-persistence-ethereum/README.md
@@ -1,4 +1,27 @@
-# `@hyperledger/cactus-plugin-persistence-ethereum`
+# `@hyperledger-cacti/cactus-plugin-persistence-ethereum`
+
+## Overview
+
+This plugin observes an Ethereum ledger through a Cacti connector and persists normalized ledger data in a relational database.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-persistence-ethereum
+```
+
+## Configuration
+
+The plugin requires an Ethereum connector instance and database connection settings. Use the setup and usage sections below for the tracked schema and synchronization workflow.
+
+## API Summary
+
+The plugin exposes status and synchronization operations through its TypeScript and OpenAPI interfaces. See [`public-api.ts`](./src/main/typescript/public-api.ts) and the endpoint section below.
 
 This plugin allows `Cactus` to persist Ethereum data into some storage (currently to a `PostgreSQL` database, but this concept can be extended further).
 Data in the database can later be analyzed and viewed in a GUI tool.
@@ -20,7 +43,7 @@ Data in the database can later be analyzed and viewed in a GUI tool.
 - Only `status` endpoint is available, all the methods must be called directly on the plugin instance for now.
 - Monitored ERC20 tokens should be added before synchronizing the database (previous transfers will not be parsed correctly if you later add the token).
 
-## Getting Started
+## Usage
 
 Clone the git repository on your local machine. Follow these instructions that will get you a copy of the project up and running on your local machine for development and testing purposes.
 
@@ -68,7 +91,7 @@ ETHEREUM_RPC_WS_HOST=ws://127.0.0.1:8546 SUPABASE_CONNECTION_STRING=postgresql:/
 
 #### Complete Sample Scenario
 
-Location: [./src/test/typescript/manual/common-setup-methods](./src/test/typescript/manual/common-setup-methods)
+Location: [./src/test/typescript/manual/complete-sample-scenario.ts](./src/test/typescript/manual/complete-sample-scenario.ts)
 
 This script starts the test Ethereum ledger for you, deploys a sample ERC721 contract, and mints some tokens. Then it synchronizes everything to a database and monitors for all new blocks. This script can also be used for manual, end-to-end tests of a plugin.
 
@@ -84,7 +107,7 @@ Custom supabase can be set with environment variable `SUPABASE_CONNECTION_STRING
 SUPABASE_CONNECTION_STRING=postgresql://postgres:your-super-secret-and-long-postgres-password@127.0.0.1:5432/postgres npm run complete-sample-scenario
 ```
 
-### Usage
+### Quick Start
 
 Instantiate a new `PluginPersistenceEthereum` instance:
 
@@ -140,7 +163,7 @@ DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-persistence-ethereum/ -f
 
 ## Endpoints
 
-### StatusV1 (`/api/v1/plugins/@hyperledger/cactus-plugin-persistence-ethereum/status`)
+### StatusV1 (`/api/v1/plugins/@hyperledger-cacti/cactus-plugin-persistence-ethereum/status`)
 
 - Returns status of the plugin (latest block read, failed blocks, is monitor running, etc...)
 
@@ -192,7 +215,7 @@ DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-persistence-ethereum/ -f
 
 - Synchronize entire ledger state with the database.
 
-## Running the tests
+## Testing
 
 To run all the tests for this persistence plugin to ensure it's working correctly execute the following from the root of the `cactus` project:
 

--- a/packages/cactus-plugin-persistence-fabric/README.md
+++ b/packages/cactus-plugin-persistence-fabric/README.md
@@ -1,4 +1,27 @@
-# `@hyperledger/cactus-plugin-persistence-fabric`
+# `@hyperledger-cacti/cactus-plugin-persistence-fabric`
+
+## Overview
+
+This plugin observes a Fabric ledger through a Cacti connector and persists normalized ledger data in a relational database.
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-persistence-fabric
+```
+
+## Configuration
+
+The plugin requires a Fabric connector instance and database connection settings. Use the setup and usage sections below for the tracked schema and synchronization workflow.
+
+## API Summary
+
+The plugin exposes status and synchronization operations through its TypeScript and OpenAPI interfaces. See [`public-api.ts`](./src/main/typescript/public-api.ts) and the endpoint section below.
 
 This plugin allows `Cacti` to persist Hyperledger Fabric data into some storage (currently to a `PostgreSQL` database, but this concept can be extended further).
 Data in the database can later be analyzed and viewed in a GUI tool.
@@ -19,7 +42,7 @@ Data in the database can later be analyzed and viewed in a GUI tool.
 - For now, the database schema is not considered public and can change over time (i.e., writing own application that reads data directly from the database is discouraged).
 - Only `status` endpoint is available, all the methods must be called directly on the plugin instance for now.
 
-## Getting Started
+## Usage
 
 Clone the git repository on your local machine. Follow these instructions that will get you a copy of the project up and running on your local machine for development and testing purposes.
 
@@ -52,7 +75,7 @@ npm install
 CACTUS_FABRIC_ALL_IN_ONE_CONTAINER_NAME=fabric_all_in_one_testnet_2x  ./setup.sh
 ```
 
-Once you have an Fabric ledger ready, you need to start the [Ethereum Cacti Connector](../cactus-plugin-ledger-connector-fabric/README.md). We recommend running the connector on the same ApiServer instance as the persistence plugin for better performance and reduced network overhead. See the connector package README for more instructions, or check out the [setup sample scripts](./src/test/typescript/manual).
+Once you have an Fabric ledger ready, you need to start the [Fabric Cacti Connector](../cactus-plugin-ledger-connector-fabric/README.md). We recommend running the connector on the same ApiServer instance as the persistence plugin for better performance and reduced network overhead. See the connector package README for more instructions, or check out the [setup sample scripts](./src/test/typescript/manual).
 
 #### Supabase Instance
 
@@ -85,7 +108,7 @@ node ./dist/lib/test/typescript/manual/sample-setup.js
 
 #### Complete Sample Scenario
 
-Location: [./src/test/typescript/manual/common-setup-methods](./src/test/typescript/manual/common-setup-methods)
+Location: [./src/test/typescript/manual/complete-sample-scenario.ts](./src/test/typescript/manual/complete-sample-scenario.ts)
 
 This script starts the test Hyperledger Fabric ledger for you and executes few transactions on a `basic` chaincode. Then, it synchronizes everything to a database and monitors for all new blocks. This script can also be used for manual, end-to-end tests of a plugin.
 
@@ -101,7 +124,7 @@ Custom supabase can be set with environment variable `SUPABASE_CONNECTION_STRING
 SUPABASE_CONNECTION_STRING=postgresql://postgres:your-super-secret-and-long-postgres-password@127.0.0.1:5432/postgres npm run complete-sample-scenario
 ```
 
-### Usage
+### Quick Start
 
 Instantiate a new `PluginPersistenceFabric` instance:
 
@@ -113,7 +136,7 @@ const persistencePlugin = new PluginPersistenceFabric({
   apiClient: new FabricApiClient(apiConfigOptions),
   logLevel: "info",
   instanceId: "my-instance",
-  connectionString: "postgresql://postgres:your-super-secret-and-long-postgres-password@localhost:5432/postgres",,
+  connectionString: "postgresql://postgres:your-super-secret-and-long-postgres-password@localhost:5432/postgres",
   channelName: "mychannel",
   gatewayOptions: {
     identity: signingCredential.keychainRef,
@@ -152,7 +175,7 @@ DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-persistence-fabric/ -f .
 
 ## Endpoints
 
-### StatusV1 (`/api/v1/plugins/@hyperledger/cactus-plugin-persistence-fabric/status`)
+### StatusV1 (`/api/v1/plugins/@hyperledger-cacti/cactus-plugin-persistence-fabric/status`)
 
 - Returns status of the plugin (latest block read, failed blocks, is monitor running, etc...)
 
@@ -188,7 +211,7 @@ DOCKER_BUILDKIT=1 docker build ./packages/cactus-plugin-persistence-fabric/ -f .
 
 - Synchronize entire ledger state with the database.
 
-## Running the tests
+## Testing
 
 To run all the tests for this persistence plugin to ensure it's working correctly execute the following from the root of the `cactus` project:
 

--- a/packages/cactus-plugin-satp-hermes/README.md
+++ b/packages/cactus-plugin-satp-hermes/README.md
@@ -1,13 +1,36 @@
-# @hyperledger/cactus-plugin-satp-hermes
+# `@hyperledger-cacti/cactus-plugin-satp-hermes`
+
+## Overview
 
 The Hyperledger Cacti SATP (Secure Asset Transfer Protocol) Hermes plugin provides a comprehensive implementation of the IETF SATP protocol for secure, atomic cross-chain asset transfers. This plugin enables standardized interoperability between different distributed ledger technologies.
+
+
+**Target Audience:**
+
+- [x] Developers
+- [x] Operators
+
+## Install
+
+```sh
+npm install @hyperledger-cacti/cactus-plugin-satp-hermes
+```
+
+## API Summary
+
+The package exports `SATPGateway`, `SATPGatewayConfig`, the gateway factory,
+generated API clients, protocol types, cross-chain bridge types, adapter APIs,
+and gateway configuration-loading utilities. See
+[`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export
+surface and [the bundled OpenAPI document](./src/main/json/oapi-api1-bundled.json)
+for application-to-gateway request and response schemas.
 
 ## Key Features
 
 - **Atomic Asset Transfers**: Secure, atomic asset transfers between heterogeneous blockchain networks
 - **Multi-Ledger Support**: Native support for Hyperledger Fabric, Ethereum/Besu, and extensible architecture for additional ledgers
 - **Crash Recovery**: Comprehensive crash recovery mechanisms ensuring transaction consistency and fault tolerance
-- **IETF SATP Compliance**: Full implementation of the IETF SATP protocol specification
+- **IETF SATP Compliance**: Implementation of the IETF SATP protocol specification
 - **Gateway Architecture**: Implements the gateway paradigm as defined in [Hermes research paper](https://www.sciencedirect.com/science/article/abs/pii/S0167739X21004337)
 - **Session Management**: Advanced session lifecycle management with persistent logging and state recovery
 - **Security**: Cryptographic security with digital signatures, proof verification, and secure messaging
@@ -45,7 +68,7 @@ Regarding the crash recovery procedure in place, at the moment we only support c
 
 We will be working on reducing these assumptions and making the system more resilient to faults.
 
-## Getting Started
+## Usage
 
 Clone the git repository on your local machine. Follow these instructions that will get you a copy of the project up and running on
 your local machine for development and testing purposes.
@@ -187,758 +210,21 @@ These features enhance reliability in scenarios where network or gateway disrupt
   
 ## Gateway Configuration
 
-The SATP Hermes plugin provides flexible configuration options to support various deployment scenarios. Configuration can be provided programmatically through TypeScript interfaces or loaded from JSON configuration files.
-
-### Configuration Architecture
-
-The gateway configuration follows a modular structure with the following main sections:
-
-1. **Gateway Core Configuration** - Basic gateway settings and identity
-2. **Database Configuration** - Local session storage and remote audit logging
-3. **Ledger Connections** - Blockchain-specific connection parameters
-4. **Security Configuration** - TLS, encryption, and authentication settings
-5. **Monitoring Configuration** - Metrics, health checks, and alerting
-6. **Performance Configuration** - Optimization and scaling parameters
-
-### Configuration Templates
-
-The plugin includes pre-built configuration templates for common deployment scenarios:
-
-| Template | Use Case | Description |
-|----------|----------|-------------|
-| **Development** | Local testing | Minimal security, in-memory databases, debug logging |
-| **Fabric-to-Besu** | Enterprise bridging | Production fabric to consortium Besu transfers |
-| **Besu-to-Ethereum** | DeFi bridging | Testnet to mainnet asset transfers |
-| **Multi-Ledger** | Complex interop | 3+ blockchain networks with advanced features |
-| **Production** | Enterprise deployment | Maximum security, compliance, and monitoring |
-
-### Core Gateway Interface
-
-```typescript
-export interface IPluginSatpGatewayConstructorOptions {
-  name: string;                           // Plugin instance name
-  dltIDs: string[];                      // Supported DLT identifiers
-  instanceId: string;                    // Unique instance identifier
-  keyPair?: IKeyPair;                    // Cryptographic key pair for signing
-  backupGatewaysAllowed?: string[];      // List of allowed backup gateways
-  clientHelper: ClientGatewayHelper;     // Client-side protocol helper
-  serverHelper: ServerGatewayHelper;     // Server-side protocol helper
-  knexLocalConfig?: Knex.Config;        // Local database configuration
-  knexRemoteConfig?: Knex.Config;       // Remote logging database config
-  ipfsPath?: string;                     // IPFS endpoint for distributed logging
-}
-```
-
-### Configuration Examples
-
-#### Reusing Deployed Wrapper Contracts
-
-When you already have bridge wrapper contracts on-chain, provide their identifiers in the leaf configuration so the deployment step skips redeployment. The CLI entrypoint loads the configuration, `validateCCConfig` verifies the schema, and the bridge manager attaches each leaf to the supplied contract details.
-
-##### Fabric Leaf Wrapper Example
-```typescript
-const fabricWrapperConfig = {
-  networkIdentification: {
-    id: "FabricLedgerTestNetwork",
-    ledgerType: "FABRIC_2",
-  },
-  channelName: "mychannel",
-  signingCredential: {/* Fabric signing credential */},
-  connectorOptions: {/* Fabric connector options */},
-  wrapperContractName: "satp-wrapper-fabric", // Existing chaincode package name
-  claimFormats: [1],
-};
-```
-
-##### Besu Leaf Wrapper Example
-```typescript
-const besuWrapperConfig = {
-  networkIdentification: {
-    id: "BesuLedgerTestNetwork",
-    ledgerType: "BESU_2X",
-  },
-  signingCredential: {/* Besu signing credential */},
-  connectorOptions: {/* Besu connector options */},
-  wrapperContractName: "BesuWrapper",
-  wrapperContractAddress: "0x1234...cdef",
-  claimFormats: [1],
-};
-```
-
-##### Ethereum Leaf Wrapper Example
-```typescript
-const ethereumWrapperConfig = {
-  networkIdentification: {
-    id: "EthereumLedgerTestNetwork",
-    ledgerType: "ETHEREUM",
-  },
-  signingCredential: {/* Ethereum signing credential */},
-  connectorOptions: {/* Ethereum connector options */},
-  wrapperContractName: "EthereumWrapper",
-  wrapperContractAddress: "0x9876...abcd",
-  claimFormats: [1],
-};
-```
-
-If both `wrapperContractName` and `wrapperContractAddress` are present (Fabric only requires the name), leaf deployment logs that contracts already exist and continues without redeploying them.
-
-#### Fabric Configuration Example:
-Comprehensive configuration examples are available in the `src/examples/config/` directory:
-
-#### Quick Start - Development Configuration
-
-```typescript
-import { developmentGatewayConfig } from './src/examples/config/gateway-configs';
-
-const gateway = new FabricSatpGateway({
-  name: "dev-gateway",
-  dltIDs: ["local-fabric", "local-besu"],
-  instanceId: "dev-001",
-  keyPair: Secp256k1Keys.generateKeyPairsBuffer(),
-  clientHelper: new ClientGatewayHelper(),
-  serverHelper: new ServerGatewayHelper(),
-  knexLocalConfig: {
-    client: 'sqlite3',
-    connection: { filename: ':memory:' },
-    useNullAsDefault: true
-  }
-});
-```
-
-#### Production Configuration from JSON
-
-```typescript
-import * as fs from 'fs';
-
-// Load configuration from JSON file
-const config = JSON.parse(
-  fs.readFileSync('./src/examples/config/production-gateway.json', 'utf8')
-);
-
-// Environment variable substitution
-const processedConfig = processEnvironmentVariables(config);
-
-// Create gateway instance
-const gateway = new FabricSatpGateway(processedConfig);
-```
-
-### Configuration Validation
-
-The plugin provides built-in configuration validation:
-
-```typescript
-import { validateConfiguration } from './src/examples/config/gateway-configs';
-
-try {
-  validateConfiguration(config);
-  console.log('✓ Configuration is valid');
-} catch (error) {
-  console.error('✗ Configuration validation failed:', error.message);
-}
-```
-
-### Environment-Specific Settings
-
-#### Development Environment
-- **Database**: In-memory SQLite for fast testing
-- **Security**: Disabled TLS/authentication for simplicity
-- **Logging**: Verbose debug logging enabled
-- **Monitoring**: Basic health checks only
-
-#### Production Environment
-- **Database**: PostgreSQL with SSL and connection pooling
-- **Security**: Full TLS/mTLS with certificate-based authentication
-- **Logging**: Structured logging with audit trails
-- **Monitoring**: Comprehensive metrics, alerting, and dashboards
-
-#### Hyperledger Fabric Configuration
-
-Fabric gateways require connection profiles, MSP configuration, and channel/chaincode details:
-
-```json
-{
-  "fabric": {
-    "type": "fabric",
-    "networkId": "fabric-production",
-    "connectorUrl": "https://fabric-connector.example.com:4000",
-    "signingCredential": {
-      "keychainId": "fabric-keychain",
-      "keychainRef": "gateway-identity",
-      "type": "VAULT_X509"
-    },
-    "channelName": "asset-transfer-channel",
-    "contractName": "satp-asset-wrapper",
-    "connectionProfile": {
-      "name": "production-network",
-      "organizations": { ... },
-      "peers": { ... },
-      "orderers": { ... }
-    }
-  }
-}
-```
-
-#### Besu/Ethereum Configuration
-
-Ethereum-compatible networks use Web3 signing credentials and contract addresses:
-
-```json
-{
-  "besu": {
-    "type": "besu",
-    "networkId": "besu-mainnet",
-    "connectorUrl": "https://besu-connector.example.com:4000",
-    "web3SigningCredential": {
-      "transactionSignerEthAccount": "${ETH_ACCOUNT}",
-      "secret": "${ETH_PRIVATE_KEY}",
-      "type": "PRIVATE_KEY_HEX"
-    },
-    "contractName": "SATPAssetWrapper",
-    "contractAddress": "${CONTRACT_ADDRESS}",
-    "rpcEndpoints": {
-      "http": "https://mainnet.infura.io/v3/${PROJECT_ID}",
-      "ws": "wss://mainnet.infura.io/ws/v3/${PROJECT_ID}"
-    },
-    "gasConfig": {
-      "gasLimit": "3000000"
-    }    
-  }
-}
-```
-
-### Security Configuration Choices
-
-#### Certificate-Based Authentication (Recommended for Production)
-
-```json
-{
-  "security": {
-    "enableTLS": true,
-    "certificatePath": "/certs/gateway.crt",
-    "privateKeyPath": "/certs/gateway.key",
-    "enableMTLS": true,
-    "clientCACertPath": "/certs/client-ca.crt",
-    "encryption": {
-      "algorithm": "AES-256-GCM",
-      "keyRotationInterval": "12h"
-    }
-  }
-}
-```
-
-#### OAuth2 Integration
-
-```json
-{
-  "api": {
-    "authentication": {
-      "enabled": true,
-      "type": "oauth2",
-      "oauthServerUrl": "https://oauth.example.com",
-      "clientId": "${OAUTH_CLIENT_ID}",
-      "clientSecret": "${OAUTH_CLIENT_SECRET}",
-      "scope": ["satp:read", "satp:write"]
-    }
-  }
-}
-```
-
-### Database Configuration Choices
-
-#### SQLite (Development/Testing)
-```json
-{
-  "database": {
-    "local": {
-      "client": "sqlite3",
-      "connection": { "filename": ":memory:" },
-      "useNullAsDefault": true
-    }
-  }
-}
-```
-
-#### PostgreSQL (Production)
-```json
-{
-  "database": {
-    "local": {
-      "client": "postgresql",
-      "connection": {
-        "host": "${DB_HOST}",
-        "port": 5432,
-        "user": "${DB_USER}",
-        "password": "${DB_PASSWORD}",
-        "database": "${DB_NAME}",
-        "ssl": { "rejectUnauthorized": true }
-      },
-      "pool": { "min": 10, "max": 50 }
-    }
-  }
-}
-```
-
-### Monitoring Configuration Choices
-
-#### Basic Monitoring (Development)
-```json
-{
-  "monitoring": {
-    "enabled": true,
-    "healthCheckPort": 8080,
-    "prometheus": { "enabled": false }
-  }
-}
-```
-
-#### Advanced Monitoring (Production)
-```json
-{
-  "monitoring": {
-    "enabled": true,
-    "metricsPort": 9090,
-    "healthCheckPort": 8080,
-    "prometheus": { "enabled": true, "endpoint": "/metrics" },
-    "grafana": { "dashboardUrl": "https://grafana.example.com" },
-    "alerting": {
-      "enabled": true,
-      "pagerduty": { "integrationKey": "${PAGERDUTY_KEY}" },
-      "slack": { "webhookUrl": "${SLACK_WEBHOOK}" },
-      "email": { "recipients": ["ops@example.com"] }
-    }
-  }
-}
-```
-
-#### OpenTelemetry (Metrics, Traces, Logs)
-
-The gateway exports metrics, traces, and logs over OTLP/HTTP through its
-`MonitorService`. Telemetry is **opt-in**:
-- The `enabled` option is set to `true` when creating the gateway/monitor, or
-- An `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is set 
-
-Exporter endpoints are resolved as follows:
-
-- If `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the per-signal URLs are derived from
-  it (`/v1/metrics`, `/v1/traces`, `/v1/logs`).
-- Explicit `otelMetricsExporterUrl` / `otelTracesExporterUrl` /
-  `otelLogsExporterUrl` options take precedence over the environment variable.
-- If nothing is configured, the exporter endpoints are left **undefined** —
-  there is no implicit `http://localhost:4318` fallback.
-
-When telemetry **is** enabled but initialization fails (for example, a
-configured collector is unreachable), the gateway surfaces the error instead of
-silently continuing. A collector that was explicitly configured but cannot be
-reached is treated as a real misconfiguration that the operator should fix.
-
-```bash
-# Enable telemetry by pointing the gateway at a collector
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector:4318"
-```
-
-
-### Performance Configuration Choices
-
-#### Standard Performance
-```json
-{
-  "performance": {
-    "sessionPoolSize": 100,
-    "maxConcurrentTransfers": 50,
-    "transferTimeout": "10m"
-  }
-}
-```
-
-#### High-Performance Configuration
-```json
-{
-  "performance": {
-    "sessionPoolSize": 500,
-    "maxConcurrentTransfers": 200,
-    "transferTimeout": "5m",
-    "retryPolicy": {
-      "maxRetries": 5,
-      "backoffMultiplier": 1.5,
-      "initialBackoffMs": 1000
-    },
-    "caching": {
-      "enabled": true,
-      "redis": {
-        "host": "${REDIS_HOST}",
-        "password": "${REDIS_PASSWORD}"
-      }
-    }
-  }
-}
-```
-
-### Configuration File Usage
-
-All configuration examples are available as JSON files in `src/examples/config/`:
-
-```bash
-# Development setup
-cp src/examples/config/development-gateway.json ./gateway-config.json
-
-# Production setup with environment variables
-cp src/examples/config/production-gateway.json ./gateway-config.json
-# Set environment variables in .env or deployment system
-
-# Multi-ledger setup
-cp src/examples/config/multi-ledger-gateway.json ./gateway-config.json
-```
-
-For detailed configuration options and examples, see the [Configuration Examples Documentation](./src/examples/config/README.md).
-
-### Legacy Configuration Examples
-
-The following examples show the previous programmatic configuration approach:
-
-#### Legacy Fabric Configuration Example:
-```typescript
-const leafConfig = {
-  networkIdentification: {
-    id: "FabricLedgerTestNetwork",        // Unique identifier for the network
-    ledgerType: "FABRIC_2"                // Ledger type constant for Fabric v2
-  },
-  userIdentity: {
-    credentials: {
-      certificate: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
-      privateKey: "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
-    },
-    mspId: "Org2MSP",                      // Membership Service Provider ID
-    type: "X.509"                          // Credential type; typically X.509 for Fabric
-  },
-  channelName: "mychannel",                // Fabric channel name
-  targetOrganizations: [
-    {
-      CORE_PEER_TLS_ENABLED: "true",
-      CORE_PEER_LOCALMSPID: "Org1MSP",
-      CORE_PEER_TLS_CERT_FILE: "/path/to/tls/server.crt",
-      ...
-      ORDERER_TLS_ROOTCERT_FILE: "/path/to/orderer/tls/ca.crt"
-    },
-    // ... (repeat as needed for other organizations)
-  ],
-  caFile: "/path/to/orderer/tls/ca.crt",      // Path to Certificate Authority root cert
-  ccSequence: 1,                              // Chaincode sequence/version number
-  orderer: "orderer.example.com:7050",        // Orderer endpoint
-  ordererTLSHostnameOverride: "orderer.example.com",
-  connTimeout: 60,                            // Connection timeout in seconds
-  mspId: "Org2MSP",
-  connectorOptions: {
-    dockerBinary: "/usr/local/bin/docker",    // Path to Docker binary (for CLI interaction)
-    peerBinary: "/fabric-samples/bin/peer",   // Path to peer binary
-    goBinary: "/usr/local/go/bin/go",         // Path to Go binary
-    cliContainerEnv: { ... },                 // Environment variables for CLI peer container
-    sshConfig: {                              // SSH access details (if interacting over SSH)
-      host: "172.20.0.6",
-      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----\n",
-      username: "root",
-      port: 22
-    },
-    connectionProfile: { ... },               // Hyperledger Fabric connection profile object
-    discoveryOptions: {
-      enabled: true,
-      asLocalhost: false
-    },
-    eventHandlerOptions: {
-      strategy: "NETWORK_SCOPE_ALLFORTX",
-      commitTimeout: 300
-    }
-  },
-  wrapperContractName: "exampleWrapperContractName", // Only used if the contract was already deployed, in fabric the name identifies the contract
-  claimFormats: [1]                           // Claim format identifiers (application-specific)
-}
-```
-#### Besu Configuration Example:
-```typescript
-const leafConfig = {
-  networkIdentification: {
-    id: "BesuLedgerTestNetwork",              // Unique identifier for the network
-    ledgerType: "BESU_2X"                     // Ledger type constant for Besu 2.x
-  },
-  signingCredential: {
-    transactionSignerEthAccount: "0x736dC9B8258Ec5ab2419DDdffA9e1fa5C201D0b4", // ETH account (public key) of the owner of the bridge that signs transactions
-    secret: "0xc31e76f70d6416337d3a7b7a8711a43e30a14963b5ba622fa6c9dbb5b4555986", // Private key in hex
-    type: "PRIVATE_KEY_HEX"
-  },
-  gasConfig: {
-    gasLimit: "6000000",  // Default gas limit for transactions
-  },
-  connectorOptions: {
-    rpcApiHttpHost: "http://172.20.0.6:8545", // Besu JSON-RPC HTTP endpoint
-    rpcApiWsHost: "ws://172.20.0.6:8546"      // Besu JSON-RPC WebSocket endpoint
-  },
-  wrapperContractName: "exampleWrapperContractName", // Used if we want to use a custom name, if not given it will be provided by the leaf
-  wrapperContractAddress: "0x09D16c22216BC873e53c8D93A38420f48A81dF1B", // Only used if the contract was already deployed
-  claimFormats: [1]                           // Claim format identifiers (application-specific)
-}
-```
-#### Ethereum Configuration Example:
-```typescript
-const leafConfig = {
-  networkIdentification: {
-    id: "EthereumLedgerTestNetwork",          // Unique identifier for the network
-    ledgerType: "ETHEREUM"                    // Ledger type constant for Ethereum
-  },
-  signingCredential: {
-    transactionSignerEthAccount: "0x09D16c22216BC873e53c8D93A38420f48A81dF1B", // ETH account (public key) of the owner of the bridge that signs transactions
-    secret: "test",                                // Key store password or secret
-    type: "GETH_KEYCHAIN_PASSWORD"                 // Credential type for geth keychain
-  },
-  gasConfig: {
-    gas: "6721975", // Default gas limit for transactions
-    gasPrice: "20000000000" // Default gas Price
-  },                                    
-  connectorOptions: {
-    rpcApiHttpHost: "http://172.20.0.7:8545",     // Ethereum JSON-RPC HTTP endpoint
-    rpcApiWsHost: "ws://172.20.0.7:8546"          // Ethereum JSON-RPC WebSocket endpoint
-  },
-  wrapperContractName: "exampleWrapperContractName", // Used if we want to use a custom name, if not given it will be provided by the leaf
-  wrapperContractAddress: "0x09D16c22216BC873e53c8D93A38420f48A81dF1B", // Only used if the contract was already deployed
-  claimFormats: [1]                               // Claim format identifiers (application-specific)
-}
-```
-
-### Gateway Example (One Leaf Using Existing Wrapper)
-```typescript
-const gatewayConfig = {
-  gid: {
-    id: "gatewayId",
-    name: "GatewayWithBesuConnection",
-    identificationCredential: {
-      signingAlgorithm: "SECP256K1",
-      pubKey: "0x03a34e1d66b78e47fa1bba3445a6019acb5b9c87d0c6ad81c09e7d496682ae81fc",
-    },
-    version: [{ Core: "v02", Architecture: "v02", Crash: "v02" }],
-    proofID: "mockProofID10",
-    address: "http://gateway1.satp-hermes",
-  },
-  logLevel: "TRACE",
-  counterPartyGateways: [],
-  localRepository: localDbKnexConfig,
-  remoteRepository: remoteDbKnexConfig,
-  environment: "development",
-  ontologyPath: "/opt/cacti/satp-hermes/ontologies",
-  enableCrashRecovery: true,
-  ccConfig: {
-    bridgeConfig: [
-      {
-        networkIdentification: {
-          id: "BesuLedgerTestNetwork",
-          ledgerType: "BESU_2X",
-        },
-        signingCredential: {
-          transactionSignerEthAccount: "0x736dC9B8258Ec5ab2419DDdffA9e1fa5C201D0b4",
-          secret: "0xc31e76f70d6416337d3a7b7a8711a43e30a14963b5ba622fa6c9dbb5b4555986",
-          type: "PRIVATE_KEY_HEX",
-        },
-        gasConfig: {
-          gasLimit: "6000000",
-        },        
-        connectorOptions: {
-          rpcApiHttpHost: "http://172.20.0.6:8545",
-          rpcApiWsHost: "ws://172.20.0.6:8546",
-        },
-        wrapperContractName: "BesuWrapper",
-        wrapperContractAddress: "0x09D16c22216BC873e53c8D93A38420f48A81dF1B",
-        claimFormats: [1],
-      },
-    ],
-  },
-};
-```
-#### Notes:
-- **Field values:** Replace placeholders (such as file paths, endpoint addresses, credentials, etc.) with values appropriate for your environment.
-- **Security**: Credentials and secret material (certificates, private keys, etc.) must be handled securely, never checked into version control, and managed via secure secrets management.
-- **claimFormats**: The claimFormats array may be customized according to the consuming application's expectations.
-- For detailed schema and supported options, refer to your platform's documentation for each supported ledger.
+Use the tracked gateway JSON examples and the `SATPGatewayConfig` interface as
+the configuration sources of truth. The standalone CLI loads
+`config/config.json` and optionally `config/adapter-config.yml` from its
+working directory.
+
+- [Gateway configuration](./docs/configuration.md)
+- [Database and migrations](./docs/database.md)
+- [Operator deployment and health checks](./docs/operations.md)
 
 ## Adapter Layer (API Type 3)
 
-The SATP Hermes plugin includes an Adapter Layer (API Type 3) that enables external systems to integrate with and control SATP transfers through webhook-based communication. This layer facilitates observability, compliance enforcement, and custom business logic integration.
-
-### Architecture
-
-The Adapter Layer utilizes the `AdapterManager` to orchestrate webhooks based on the configured "Execution Points" within the SATP protocol.
-- **Outbound Webhooks**: Asynchronous notifications for monitoring/logging.
-- **Inbound Webhooks**: Blocking calls requiring external approval to proceed (e.g., AML/KYC checks).
-
-### Configuration
-
-Adapters are defined in the `adapterConfig` section of the Gateway configuration.
-For the complete schema, refer to [src/main/typescript/adapters/adapter-config.ts](src/main/typescript/adapters/adapter-config.ts).
-
-### Getting Started (Adapter Layer)
-
-Runnable adapter-layer demos and end-to-end walkthrough material now live in the
-[hyperledger-cacti/cacti-demos](https://github.com/hyperledger-cacti/cacti-demos)
-repository so this package can stay focused on the SATP Hermes implementation.
-
-- **Demo Repository**:
-  [hyperledger-cacti/cacti-demos](https://github.com/hyperledger-cacti/cacti-demos)
-- **Package Fixtures**: `src/test/yaml/fixtures/`
-
-### Adapter Layer Overview
-
-The adapter layer provides two types of webhook integrations:
-
-| Type | Direction | Purpose |
-|------|-----------|---------|
-| **Outbound Webhooks** | Gateway → External System | Notify external systems about SATP events |
-| **Inbound Webhooks** | External System → Gateway | Allow external systems to approve/reject transfers |
-
-### Key Concepts
-
-- **Execution Points**: Adapters are triggered at specific points in the SATP protocol (stage + step + order)
-- **Adapters**: Configuration units that define which webhooks to call and when
-- **Session Control**: Inbound webhooks can pause transfers pending external approval
-
-### Outbound Webhooks
-
-Outbound webhooks notify external systems about SATP activity. The gateway POSTs payload data to configured URLs and waits for a response before continuing.
-
-```yaml
-adapters:
-  - id: "notification-adapter"
-    name: "Transfer Notification"
-    executionPoints:
-      - stage: "stage0"
-        step: newSessionRequest
-        point: "before"
-    outboundWebhook:
-      url: "https://compliance.example.com/webhook/notify"
-      timeoutMs: 5000
-      retryAttempts: 3
-      retryDelayMs: 1000
-    active: true
-    priority: 1
-```
-
-### Inbound Webhooks and Approval Workflow
-
-Inbound webhooks enable external systems to control SATP transfer flow. When an adapter with an inbound webhook executes, the gateway pauses and waits for an external decision.
-
-```yaml
-adapters:
-  - id: "compliance-approval"
-    name: "Compliance Approval"
-    executionPoints:
-      - stage: "stage1"
-        step: checkTransferProposalRequestMessage
-        point: "after"
-    inboundWebhook:
-      timeoutMs: 300000  # 5 minutes for manual review
-    active: true
-    priority: 1
-```
-
-#### Decision Endpoint
-
-External systems submit decisions to the gateway's inbound webhook decide endpoint:
-
-```
-POST /api/v1/@hyperledger/cactus-plugin-satp-hermes/webhook/inbound/decide
-```
-
-**Request Body:**
-```json
-{
-  "adapterId": "compliance-approval",
-  "sessionId": "session-abc-123",
-  "continue": true,
-  "reason": "Compliance check passed - all KYC requirements met"
-}
-```
-
-**Response:**
-```json
-{
-  "accepted": true,
-  "sessionId": "session-abc-123",
-  "message": "Decision accepted, transfer resumed",
-  "timestamp": "2024-01-15T10:30:00.000Z"
-}
-```
-
-#### Decision Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `adapterId` | string | Yes | Adapter that originally paused the transfer |
-| `sessionId` | string | Yes | Session identifier for the paused transfer |
-| `continue` | boolean | Yes | `true` to resume, `false` to abort |
-| `contextId` | string | No | Optional context identifier |
-| `reason` | string | No | Human-readable justification for audit |
-| `data` | object | No | Optional payload from external system |
-
-### Configuration Reference
-
-#### InboundWebhookConfig
-
-```typescript
-interface InboundWebhookConfig {
-  // Inherited from BaseWebhookConfig
-  timeoutMs?: number;       // Timeout for waiting for decision
-  payloadTemplate?: string; // Template for context data
-  retryAttempts?: number;   // Retry configuration
-  retryDelayMs?: number;
-  
-  // Inbound-specific
-  priority?: number;        // Order when multiple inbound webhooks
-}
-```
-
-#### OutboundWebhookConfig
-
-```typescript
-interface OutboundWebhookConfig {
-  url: string;              // Absolute HTTPS endpoint URL
-  timeoutMs?: number;       // HTTP request timeout
-  payloadTemplate?: string; // JSON/XML template for request body
-  retryAttempts?: number;   // Number of retry attempts
-  retryDelayMs?: number;    // Delay between retries
-  priority?: number;        // Order when multiple outbound webhooks
-}
-```
-
-### Execution Points
-
-Adapters can be configured to execute at any combination of:
-
-- **Stages**: stage0 (Initialization), stage1 (Transfer Agreement), stage2 (Lock Evidence), stage3 (Commitment)
-- **Steps**: Protocol-specific steps within each stage (e.g., `newSessionRequest`, `checkTransferProposalRequestMessage`)
-- **Points**: `before`, `during`, `after`, or `rollback`
-
-### Example: Complete Adapter Configuration
-
-```yaml
-adapters:
-  - id: "validation-adapter"
-    name: "Transfer Validation Webhook"
-    description: "Validates transfer requests and notifies compliance"
-    executionPoints:
-      - stage: "stage0"
-        step: checkNewSessionRequest
-        point: "before"
-    outboundWebhook:
-      url: "http://localhost:9223/webhook/outbound/validate"
-      timeoutMs: 5000
-      retryAttempts: 3
-      retryDelayMs: 1000
-    inboundWebhook:
-      timeoutMs: 300000
-    active: true
-    priority: 1
-
-global:
-  timeoutMs: 3000
-  retryAttempts: 5
-  retryDelayMs: 500
-  logLevel: "debug"
-```
+The adapter layer connects SATP protocol execution points to outbound webhooks
+and optional inbound approval workflows. Its configuration schema, ordering,
+timeouts, decision endpoint, and execution points are maintained in the
+[API Type 3 adapter specification](./docs/api3-adapter-spec.md).
 
 ## Containerization
 
@@ -948,7 +234,7 @@ In the project root directory run these commands on the terminal:
 
 ```sh
 yarn configure
-yarn lerna run build:bundle --scope=@hyperledger/cactus-plugin-satp-hermes
+yarn lerna run build:bundle --scope=@hyperledger-cacti/cactus-plugin-satp-hermes
 ```
 
 ### Build the image:
@@ -976,7 +262,7 @@ prefer to run it from the project root directory then:
 ```sh
 docker compose \
   --project-directory ./packages/cactus-plugin-satp-hermes/ \
-  -f ./packages/cactus-plugin-satp-hermes/docker-compose.yml \
+  -f ./packages/cactus-plugin-satp-hermes/docker-compose-satp.yml \
   up \
   --build
 ```
@@ -1020,6 +306,19 @@ docker-compose -f docker-compose-satp.yml build
 # List running containers
 docker-compose -f docker-compose-satp.yml ps
 ```
+
+## Testing
+
+From the repository root, run the focused suites through the package workspace:
+
+```sh
+yarn workspace @hyperledger-cacti/cactus-plugin-satp-hermes test:unit
+yarn workspace @hyperledger-cacti/cactus-plugin-satp-hermes test:integration:adapter
+```
+
+The package also defines focused gateway, bridge, oracle, recovery, rollback, and
+container integration suites. These require the corresponding external ledger
+or container dependencies.
 
 ## Contributing
 We welcome contributions to Hyperledger Cacti in many forms, and there’s always interesting challenges!

--- a/packages/cactus-plugin-satp-hermes/docs/configuration.md
+++ b/packages/cactus-plugin-satp-hermes/docs/configuration.md
@@ -1,0 +1,41 @@
+<!-- --8<-- [start:content] -->
+# SATP Hermes Gateway Configuration
+
+SATP Hermes can be created programmatically with `SATPGatewayConfig` or started through the package CLI with a JSON configuration file.
+
+## Tracked examples
+
+The repository contains [Gateway 1](https://github.com/hyperledger-cacti/cacti/blob/main/packages/cactus-plugin-satp-hermes/src/examples/config/satp-gateway1-config.json) and [Gateway 2](https://github.com/hyperledger-cacti/cacti/blob/main/packages/cactus-plugin-satp-hermes/src/examples/config/satp-gateway2-config.json) examples. Additional oracle test cases are available in [`src/examples/config/`](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-satp-hermes/src/examples/config). The example credentials are for local development and must not be reused in deployed environments.
+
+## Programmatic configuration
+
+`SATPGatewayConfig` supports the following top-level fields:
+
+| Field | Required | Default or behavior |
+| --- | --- | --- |
+| `pluginRegistry` | Yes | No default for direct construction. |
+| `gid` | No | A local gateway identity is generated. |
+| `counterPartyGateways` | No | Empty array. |
+| `keyPair` | No | A secp256k1 key pair is generated. |
+| `environment` | No | `"development"`. |
+| `validationOptions` | No | Empty object. |
+| `privacyPolicies`, `mergePolicies` | No | Empty arrays. |
+| `ccConfig` | No | Empty bridge and oracle configuration. |
+| `localRepository` | No | Per-instance SQLite configuration. |
+| `remoteRepository` | No | Disabled. |
+| `auditRepository` | No | In-memory SQLite configuration. |
+| `oracleLogRepository` | No | Per-instance SQLite configuration. |
+| `enableCrashRecovery` | No | `false`. |
+| `monitorService` | No | An enabled monitor service is created. |
+| `claimFormat` | No | The default claim format. |
+| `ontologyPath`, `extensions`, `adapterConfig`, `supportedLedgers` | No | Feature-specific configuration. |
+| `logLevel` | No | `"INFO"`. |
+
+See [`SATPGatewayConfig`](https://github.com/hyperledger-cacti/cacti/blob/main/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts) for field types and validation details.
+
+## CLI configuration
+
+The CLI requires `/opt/cacti/satp-hermes/config/config.json` by default and optionally loads `/opt/cacti/satp-hermes/config/adapter-config.yml`. Programmatic callers can override `workDir`, `configPath`, and `adapterConfigPath` through `launchGateway()`.
+
+The CLI validates the identity, counterparties, key pair, environment, policies, repositories, cross-chain configuration, extensions, and optional adapter configuration before constructing the gateway. For adapter fields and execution-point semantics, see the [API Type 3 adapter specification](/cacti/satp-hermes/api3-adapter-spec/).
+<!-- --8<-- [end:content] -->

--- a/packages/cactus-plugin-satp-hermes/docs/database.md
+++ b/packages/cactus-plugin-satp-hermes/docs/database.md
@@ -1,0 +1,30 @@
+<!-- --8<-- [start:content] -->
+# SATP Hermes Database and Migrations
+
+SATP Hermes uses Knex repositories for local protocol logs, replicated remote logs, audit entries, and oracle logs. Repository initialization runs the tracked Knex migrations before the repository is used.
+
+## Default storage
+
+When repository options are omitted, local and oracle logs use per-instance SQLite files, audit entries use an in-memory SQLite database, and the remote log repository is disabled. The file-backed defaults are intended for development and isolated runtime instances.
+
+## External database configuration
+
+`SATPGatewayConfig` accepts Knex configuration objects through `localRepository`, `remoteRepository`, `auditRepository`, and `oracleLogRepository`. The tracked production configurations for remote and audit storage use PostgreSQL and read:
+
+| Variable | Purpose |
+| --- | --- |
+| `ENV_PATH` | Optional dotenv file loaded by the Knex configuration modules. |
+| `DB_HOST` | PostgreSQL host. |
+| `DB_PORT` | PostgreSQL port. |
+| `DB_USER` | PostgreSQL user. |
+| `DB_PASSWORD` | PostgreSQL password. |
+| `DB_NAME` | PostgreSQL database name. |
+
+Do not place credentials in tracked gateway example files. Supply secrets through the deployment platform or an untracked environment file.
+
+## Migration behavior
+
+The repository classes call `migrate.latest()` during initialization and use the migrations under [`src/main/typescript/database/migrations/`](https://github.com/hyperledger-cacti/cacti/tree/main/packages/cactus-plugin-satp-hermes/src/main/typescript/database/migrations). Rollback support is implemented by the repository classes for controlled test and recovery flows.
+
+The package manifest currently contains legacy `db:*` scripts that reference the former `src/knex/` layout. Do not use those scripts until their paths are updated in a dedicated code change.
+<!-- --8<-- [end:content] -->

--- a/packages/cactus-plugin-satp-hermes/docs/operations.md
+++ b/packages/cactus-plugin-satp-hermes/docs/operations.md
@@ -1,0 +1,33 @@
+<!-- --8<-- [start:content] -->
+# Operating SATP Hermes
+
+## Deployment topology
+
+The tracked [Compose file](https://github.com/hyperledger-cacti/cacti/blob/main/packages/cactus-plugin-satp-hermes/docker-compose-satp.yml) starts one SATP Hermes gateway and one Grafana OpenTelemetry LGTM container. The gateway publishes its protocol server on port `3010`, client service on port `3011`, and OpenAPI service on container port `4010`. The tracked Compose mapping exposes the OpenAPI service on host port `3012`.
+
+The gateway CLI uses `/opt/cacti/satp-hermes` as its default working directory. Mount gateway configuration into its `config` subdirectory. See [Gateway Configuration](./configuration.md) for the exact paths.
+
+## Container environment
+
+| Variable | Tracked value or purpose |
+| --- | --- |
+| `NODE_ENV` | `production` in the gateway image. |
+| `TZ` | `Etc/UTC` in the gateway image. |
+| `DATABASE_CLIENT` | `sqlite3` in the gateway image. |
+| `DATABASE_NAME` | `/opt/cacti/satp-hermes/database/satp.sqlite` in the gateway image. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` in the tracked Compose service. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://otel-lgtm:4318` in the tracked Compose service. |
+
+Database configuration modules also support the PostgreSQL variables described in [Database and Migrations](./database.md).
+
+## Health and status endpoints
+
+- `GET /api/v1/@hyperledger-cacti/cactus-plugin-satp-hermes/healthcheck` reports service health. The container health check calls this endpoint on port `4010` and expects `{"status":"AVAILABLE"}`.
+- `GET /api/v1/@hyperledger-cacti/cactus-plugin-satp-hermes/status` queries a transfer session by `sessionID`.
+
+The [OpenAPI document](https://github.com/hyperledger-cacti/cacti/blob/main/packages/cactus-plugin-satp-hermes/src/main/json/oapi-api1-bundled.json) is the source of truth for request and response schemas.
+
+## Startup and shutdown
+
+The CLI validates configuration, creates an isolated plugin registry, constructs `SATPGateway`, and calls `startup()`. Startup initializes repositories and cross-chain mechanisms before opening gateway services. Normal termination runs registered shutdown hooks that stop scheduled jobs, close servers, and destroy repository connections.
+<!-- --8<-- [end:content] -->

--- a/packages/cactus-test-api-client/README.md
+++ b/packages/cactus-test-api-client/README.md
@@ -1,4 +1,25 @@
-# `@hyperledger/cactus-test-api-client`
+# `@hyperledger-cacti/cactus-test-api-client`
+
+## Overview
+
+This package contains the API client integration-test harness and fixtures. It is intended for repository development and is not an application runtime dependency.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+The package is configured as part of the Cacti monorepo:
+
+```sh
+yarn configure
+```
+
+## API Summary
+
+The package public API is limited to utilities required by its integration tests. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
 
 This is the test package for the package that's called `cactus-api-client`
 
@@ -13,3 +34,19 @@ This is the test package for the package that's called `cactus-api-client`
 ### **What is a dedicated test package for?**
 
 This is a dedicated test package meaning that it verifies the integration between two packages that are somehow dependent on each other and therefore these tests cannot be added properly in the child package due to circular dependency issues and it would not be fitting to add it in the parent because the child package's tests should not be held by the parent as a matter of principle.
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cactus-test-api-client/src/test/typescript
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in the [LICENSE](../../LICENSE) file.

--- a/packages/cactus-test-cmd-api-server/README.md
+++ b/packages/cactus-test-cmd-api-server/README.md
@@ -1,4 +1,25 @@
-# `@hyperledger/cactus-test-cmd-api-server`
+# `@hyperledger-cacti/cactus-test-cmd-api-server`
+
+## Overview
+
+This package contains integration-test support for the Cacti command API server. It is intended for repository development and is not an application runtime dependency.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+The package is configured as part of the Cacti monorepo:
+
+```sh
+yarn configure
+```
+
+## API Summary
+
+The package public API is limited to utilities required by its integration tests. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
 
 This is the test package for the package that's called `cactus-cmd-api-server`
 
@@ -13,3 +34,19 @@ This is the test package for the package that's called `cactus-cmd-api-server`
 ### **What is a dedicated test package for?**
 
 This is a dedicated test package meaning that it verifies the integration between two packages that are somehow dependent on each other and therefore these tests cannot be added properly in the child package due to circular dependency issues and it would not be fitting to add it in the parent because the child package's tests should not be held by the parent as a matter of principle.
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cactus-test-cmd-api-server/src/test/typescript
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in the [LICENSE](../../LICENSE) file.

--- a/packages/cactus-test-geth-ledger/README.md
+++ b/packages/cactus-test-geth-ledger/README.md
@@ -1,4 +1,23 @@
-# `@hyperledger/cactus-test-geth-ledger`
+# `@hyperledger-cacti/cactus-test-geth-ledger`
+
+## Overview
+
+This package provides helpers for starting and controlling ephemeral go-ethereum ledgers in Cacti integration tests.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+```sh
+npm install --save-dev @hyperledger-cacti/cactus-test-geth-ledger
+```
+
+## API Summary
+
+The public API exports the Geth test-ledger helpers and related options used by Cacti test suites. See [`public-api.ts`](./src/main/typescript/public-api.ts) for the maintained export surface.
 
 Helpers for running test `go-ethereum` ledger in test scripts.
 
@@ -11,7 +30,7 @@ Helpers for running test `go-ethereum` ledger in test scripts.
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
 
-## Getting Started
+## Usage
 
 Clone the git repository on your local machine. Follow these instructions that will get you a copy of the project up and running on
 your local machine for development and testing purposes.
@@ -51,7 +70,7 @@ await ledger.start();
 const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
 ```
 
-## Running the tests
+## Testing
 
 To check that all has been installed correctly and that the test class has no errors:
 

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/README.md
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/README.md
@@ -1,4 +1,25 @@
-# `@hyperledger/cactus-test-plugin-htlc-eth-erc20`
+# `@hyperledger-cacti/cactus-test-plugin-htlc-eth-besu-erc20`
+
+## Overview
+
+This package groups the integration tests for the Besu ERC-20 HTLC plugin. It exposes no production runtime functionality.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+The package is configured as part of the Cacti monorepo:
+
+```sh
+yarn configure
+```
+
+## API Summary
+
+The package public API is intentionally empty. Its maintained functionality is the integration-test suite under [`src/test/typescript/`](./src/test/typescript/).
 
 > TODO: description
 
@@ -7,3 +28,19 @@
 ```
 // TODO: DEMONSTRATE API
 ```
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in the [LICENSE](../../LICENSE) file.

--- a/packages/cactus-test-plugin-htlc-eth-besu/README.md
+++ b/packages/cactus-test-plugin-htlc-eth-besu/README.md
@@ -1,0 +1,60 @@
+# `@hyperledger-cacti/cactus-test-plugin-htlc-eth-besu`
+
+> Integration tests for the Besu HTLC plugin.
+
+## Overview
+
+This package contains the integration and API-surface tests for
+[`@hyperledger-cacti/cactus-plugin-htlc-eth-besu`](../cactus-plugin-htlc-eth-besu/README.md).
+The suite validates the plugin's OpenAPI contract and the initialize, contract,
+status, refund, and withdrawal endpoints.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+This package is maintained as part of the Cacti monorepo. Configure the
+repository from its root before running the tests:
+
+```sh
+yarn configure
+```
+
+## Configuration
+
+The integration tests create their required plugin and ledger test fixtures.
+No separate runtime configuration API is exported by this package.
+
+## API Summary
+
+The package does not export a public API. Its
+[`public-api.ts`](./src/main/typescript/public-api.ts) file is intentionally
+empty, and the package is used to group integration tests.
+
+## Usage
+
+Use this package through its tracked integration tests rather than as a
+runtime dependency.
+
+## Testing
+
+The CI workflow runs the tracked Jest integration tests with this pattern:
+
+```text
+packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
+```
+
+Use the repository's `test:jest:all` runner from the project root when
+executing the same pattern locally.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in
+the [LICENSE](../../LICENSE) file.

--- a/packages/cactus-test-plugin-ledger-connector-besu/README.md
+++ b/packages/cactus-test-plugin-ledger-connector-besu/README.md
@@ -1,4 +1,45 @@
-# @hyperledger/cactus-test-plugin-ledger-connector-besu
+# `@hyperledger-cacti/cactus-test-plugin-ledger-connector-besu`
+
+## Overview
+
+This package groups integration tests for the Besu ledger connector and Cacti API server. It exposes no production runtime functionality.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+The package is configured as part of the Cacti monorepo:
+
+```sh
+yarn configure
+```
+
+## API Summary
+
+The package public API is limited to test support. Its maintained functionality is the integration-test suite under [`src/test/typescript/`](./src/test/typescript/).
+
+## Usage
+
+Run this package only from a configured Cacti source checkout.
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in the [LICENSE](../../LICENSE) file.
 
 This package is designed to hold test cases verifying the correct operation of
 the code in the package of similar name: `@hyperledger/cactus-plugin-ledger-connector-besu`.

--- a/packages/cactus-test-plugin-ledger-connector-ethereum/README.md
+++ b/packages/cactus-test-plugin-ledger-connector-ethereum/README.md
@@ -1,4 +1,25 @@
-# `@hyperledger/cactus-test-plugin-ledger-connector-ethereum`
+# `@hyperledger-cacti/cactus-test-plugin-ledger-connector-ethereum`
+
+## Overview
+
+This package groups integration tests for the Ethereum ledger connector and Cacti API server. It exposes no production runtime functionality.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+The package is configured as part of the Cacti monorepo:
+
+```sh
+yarn configure
+```
+
+## API Summary
+
+The package public API is limited to test support. Its maintained functionality is the integration-test suite under [`src/test/typescript/`](./src/test/typescript/).
 
 
 ## Usage
@@ -13,3 +34,19 @@ npx jest cactus-test-plugin-ledger-connector-ethereum
 ### **What is a dedicated test package for?**
 
 This is a dedicated test package meaning that it verifies the integration between two packages that are somehow dependent on each other and therefore these tests cannot be added properly in the child package due to circular dependency issues and it would not be fitting to add it in the parent because the child package's tests should not be held by the parent as a matter of principle.
+
+## Testing
+
+From the repository root, run:
+
+```sh
+yarn test:jest:all packages/cactus-test-plugin-ledger-connector-ethereum/src/test/typescript
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution requirements.
+
+## License
+
+This distribution is published under the Apache License Version 2.0 found in the [LICENSE](../../LICENSE) file.

--- a/weaver/README.md
+++ b/weaver/README.md
@@ -7,8 +7,8 @@
 
 <div align="center">
 
-[![Data Sharing Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_data-sharing.yml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_data-sharing.yml) [![Asset Transfer Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-transfer.yml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-transfer.yml)  
-[![Fabric Asset Exchange Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-exchange-fabric.yml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-exchange-fabric.yml) [![Corda Asset Exchange Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-exchange-corda.yml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-exchange-corda.yml) [![Besu Asset Exchange Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-exchange-besu.yml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_asset-exchange-besu.yml)
+[![Data Sharing Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-data-sharing.yaml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-data-sharing.yaml) [![Asset Transfer Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-transfer.yaml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-transfer.yaml)
+[![Fabric Asset Exchange Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-exchange-fabric.yaml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-exchange-fabric.yaml) [![Corda Asset Exchange Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-exchange-corda.yaml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-exchange-corda.yaml) [![Besu Asset Exchange Status](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-exchange-besu.yaml/badge.svg?event=push)](https://github.com/hyperledger-cacti/cacti/actions/workflows/test_weaver-asset-exchange-besu.yaml)
 
 </div>
 
@@ -22,19 +22,19 @@ Weaver is a framework, with a family of protocols, to enable interoperation for 
 ## Weaver Use Cases
 The framework allows two independent networks built on the same or different DLTs to interoperate on a need basis. Though presently, Weaver supports only permissioned DLTs (Hyperledger Fabric, Corda, and to some extent Hyperledger Besu), the design encompasses both permissioned and open DLTs. We expect to add support to the latter (e.g., Ethereum, Bitcoin) in due course.
 
-Weaver, in effect, allows smart contracts managing data and assets on their respective ledgers to interlink and thereby produce an augnmented business workflow that can span multiple shared ledgers and networks. The core capabilities (or use cases) in Weaver that are the building blocks for cross-network operations are:
+Weaver, in effect, allows smart contracts managing data and assets on their respective ledgers to interlink and thereby produce an augmented business workflow that can span multiple shared ledgers and networks. The core capabilities (or use cases) in Weaver that are the building blocks for cross-network operations are:
 - Data sharing across ledgers with proof of authenticity and provenance
 - Atomic asset transfers between networks
 - Atomic asset exchanges in multiple networks
 
 Each capability is implemented as a protocol with the endpoints being the respective peer networks that arrive at ledger state update decisions through consensus. See the [project overview](./OVERVIEW.md) for more information and references.
 
-With Weaver, limited-scope blockchain networks can be scaled up to a _network-of-networks_ where different DLT networks can interoperate using Weaver's protocols ad hoc, thereby creating an illusion of a worldwide distributed ledger (or blockchain) without requiring netowrks to sacrifice their independence. This is illustrated in the figure below.
+With Weaver, limited-scope blockchain networks can be scaled up to a _network-of-networks_ where different DLT networks can interoperate using Weaver's protocols ad hoc, thereby creating an illusion of a worldwide distributed ledger (or blockchain) without requiring networks to sacrifice their independence. This is illustrated in the figure below.
 
 <img src="./resources/images/weaver-vision.png">
 
 ## Weaver Components
-The framework offers common components that can be reused in networks built on any arbitrary DLT as well as design templates for components that must be built on DLT-specific tech stacks. We will strive to provide acclerators that minimize the effort involved in building DLT-specific components. Presently, we support Hyperledger Fabric and Corda, and to some extent Hyperledger Besu.
+The framework offers common components that can be reused in networks built on any arbitrary DLT as well as design templates for components that must be built on DLT-specific tech stacks. We will strive to provide accelerators that minimize the effort involved in building DLT-specific components. Presently, we support Hyperledger Fabric and Corda, and to some extent Hyperledger Besu.
 - The key platform elements are:
   * Protocol units, namely request access control, generation and verification of ledger state authenticity proofs, hash- and time-locking of assets, and claiming and unlocking of assets. These units leverage the networks' native smart contract frameworks.
   * Generic and extensible patterns for _ledger views_ and _view addresses_ for seamless inter-network communication. Our goal is to provide a basis for an eventual standard that is not tied to a particular DLT implementation.

--- a/weaver/core/network/fabric-interop-cc/libs/testutils/README.md
+++ b/weaver/core/network/fabric-interop-cc/libs/testutils/README.md
@@ -1,0 +1,28 @@
+# Fabric Interoperation Chaincode Test Utilities
+
+## Overview
+
+This Go module provides shared setup and mock utilities for Fabric interoperation chaincode tests.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+The module is consumed by the Weaver Fabric chaincode modules through its Go module path. For repository development, use the local `replace` directives defined by the consuming module's Makefile.
+
+## API Summary
+
+The maintained test helpers are implemented in [`setup.go`](./setup.go).
+
+## Usage
+
+Import the module from Fabric chaincode tests that require the shared mock setup.
+
+## Testing
+
+```sh
+go test ./...
+```

--- a/weaver/samples/fabric/go-cli/README.md
+++ b/weaver/samples/fabric/go-cli/README.md
@@ -1,0 +1,43 @@
+# Fabric Go CLI Sample
+
+## Overview
+
+This module provides the Go command-line client used by the Weaver Fabric samples. It exercises Fabric network configuration, chaincode operations, data sharing, asset transfer, and asset exchange flows.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+Install the Go version declared in [`go.mod`](./go.mod), then download module dependencies:
+
+```sh
+go mod download
+```
+
+## Configuration
+
+Copy [`.env.template`](./.env.template) to an untracked environment file and configure the target Fabric and Weaver services.
+
+## API Summary
+
+The module is a Cobra command-line application. Commands are implemented under [`cmd/`](./cmd/) and the entry point is [`fabric-cli.go`](./fabric-cli.go).
+
+## Usage
+
+Build the CLI with:
+
+```sh
+make build
+./bin/fabric-cli --help
+```
+
+Use `make build-local` when developing against the Weaver modules in this repository.
+
+## Testing
+
+```sh
+go test ./...
+```

--- a/weaver/samples/fabric/satpsimpleasset/README.md
+++ b/weaver/samples/fabric/satpsimpleasset/README.md
@@ -1,0 +1,26 @@
+# SATP Simple Asset Fabric Sample
+
+## Overview
+
+This Fabric chaincode sample implements bond and token assets used by SATP-oriented Weaver demonstrations and tests.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+Install the Go version declared in [`go.mod`](./go.mod), then run `go mod download`.
+
+## API Summary
+
+The chaincode entry point is [`main.go`](./main.go). Asset operations are implemented by the bond, token, and asset-management source files in this directory.
+
+## Usage
+
+Build against published dependencies with `make build`, or use `make build-local` to resolve Weaver dependencies from this repository.
+
+## Testing
+
+Run `make test` for published dependencies or `make test-local` for the local Weaver modules.

--- a/weaver/samples/fabric/simpleasset/README.md
+++ b/weaver/samples/fabric/simpleasset/README.md
@@ -1,0 +1,26 @@
+# Simple Asset Fabric Sample
+
+## Overview
+
+This Fabric chaincode sample implements bond and token asset operations used by Weaver interoperability tests.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+Install the Go version declared in [`go.mod`](./go.mod), then run `go mod download`.
+
+## API Summary
+
+The chaincode entry point is [`main.go`](./main.go). Asset operations are implemented by the bond, token, and asset-management source files in this directory.
+
+## Usage
+
+Build against published dependencies with `make build`, or use `make build-local` to resolve Weaver dependencies from this repository.
+
+## Testing
+
+Run `make test` for published dependencies or `make test-local` for the local Weaver modules.

--- a/weaver/samples/fabric/simpleassetandinterop/README.md
+++ b/weaver/samples/fabric/simpleassetandinterop/README.md
@@ -1,0 +1,26 @@
+# Simple Asset and Interoperation Fabric Sample
+
+## Overview
+
+This Fabric chaincode sample combines bond and token asset operations with Weaver interoperation and asset-exchange support.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+Install the Go version declared in [`go.mod`](./go.mod), then run `go mod download`.
+
+## API Summary
+
+The chaincode entry point is [`main.go`](./main.go). Asset and interoperability behavior is implemented by the source files in this directory and the Weaver asset-exchange library.
+
+## Usage
+
+Build against published dependencies with `make build`, or use `make build-local` to resolve Weaver dependencies from this repository.
+
+## Testing
+
+Run `make test` for published dependencies or `make test-local` for the local Weaver modules.

--- a/weaver/samples/fabric/simpleassettransfer/README.md
+++ b/weaver/samples/fabric/simpleassettransfer/README.md
@@ -1,0 +1,26 @@
+# Simple Asset Transfer Fabric Sample
+
+## Overview
+
+This Fabric chaincode sample implements bond and token operations plus pledge tracking for Weaver cross-network asset-transfer flows.
+
+**Target Audience:**
+
+- [x] Developers
+- [ ] Operators
+
+## Install
+
+Install the Go version declared in [`go.mod`](./go.mod), then run `go mod download`.
+
+## API Summary
+
+The chaincode entry point is [`main.go`](./main.go). Asset operations and pledge tracking are implemented by the source files in this directory.
+
+## Usage
+
+Build against published dependencies with `make build`, or use `make build-local` to resolve Weaver dependencies from this repository.
+
+## Testing
+
+Run `make test` for published dependencies or `make test-local` for the local Weaver modules.


### PR DESCRIPTION
## Description

Standardizes documentation for the remaining in-scope packages and active
extensions under the package documentation standardization effort.

- Aligns README package names with their current manifests.
- Adds focused installation, configuration, API, usage, and testing guidance.
- Updates the Cacti package index.
- Consolidates SATP Hermes configuration, database, operations, architecture,
  and API Type 3 documentation through MkDocs wrappers.
- Corrects Weaver workflow badges and adds documentation for active Fabric Go
  sample modules.

## Related issue

Addresses #4595

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md),
      including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per
      [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All
      AI-generated content has been human-reviewed before submission.