### PR TITLE
feat(satp-hermes): implement lock expiration

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage2-client-service.ts
@@ -343,7 +343,8 @@ export class Stage2ClientService extends SATPService {
             },
           );
 
-          sessionData.lockAssertionExpiration = BigInt(99999999999); //todo implement
+          sessionData.lockAssertionExpiration =
+            BigInt(Date.now()) + sessionData.lockExpirationTime;
 
           sessionData.lockAssertionClaim.signature = bufArray2HexStr(
             sign(this.Signer, sessionData.lockAssertionClaim.receipt),

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage2-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage2-server-service.ts
@@ -32,7 +32,7 @@ import {
   LockAssertionExpirationError,
   SessionError,
 } from "../../errors/satp-service-errors";
-import { SATPInternalError } from "../../errors/satp-errors";
+import { SATPError, SATPInternalError } from "../../errors/satp-errors";
 import { SessionNotFoundError } from "../../errors/satp-handler-errors";
 import { create } from "@bufbuild/protobuf";
 import { context, SpanStatusCode } from "@opentelemetry/api";
@@ -186,10 +186,11 @@ export class Stage2ServerService extends SATPService {
     return context.with(ctx, () => {
       try {
         const errorResponse = create(LockAssertionResponseSchema, {});
+        const clientError = SATPError.fromInternalError(error);
         const commonBody = create(CommonSatpSchema, {
           messageType: MessageType.ASSERTION_RECEIPT,
           error: true,
-          errorCode: error.getSATPErrorType(),
+          errorCode: clientError.errorType,
         });
 
         if (!(error instanceof SessionNotFoundError) && session != undefined) {
@@ -254,11 +255,24 @@ export class Stage2ServerService extends SATPService {
 
         sessionData.lockAssertionClaimFormat = request.lockAssertionClaimFormat; //todo check if valid
 
-        if (request.lockAssertionExpiration == BigInt(0)) {
-          throw new LockAssertionExpirationError(fnTag);
+        const currentTime = BigInt(Date.now());
+        const maximumExpiration = currentTime + sessionData.lockExpirationTime;
+
+        if (request.lockAssertionExpiration <= currentTime) {
+          throw new LockAssertionExpirationError(
+            fnTag,
+            "lock assertion already expired",
+          );
         }
 
-        sessionData.lockAssertionExpiration = request.lockAssertionExpiration; //todo check if expired
+        if (request.lockAssertionExpiration > maximumExpiration) {
+          throw new LockAssertionExpirationError(
+            fnTag,
+            "lock assertion exceeds the negotiated expiration time",
+          );
+        }
+
+        sessionData.lockAssertionExpiration = request.lockAssertionExpiration;
 
         if (
           sessionData.clientTransferNumber != "" &&

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/services.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/unit/services.test.ts
@@ -22,6 +22,7 @@ import {
   BurnAssertionClaimSchema,
   ClaimFormat,
   CredentialProfile,
+  Error as SATPErrorType,
   LockAssertionClaimFormatSchema,
   LockAssertionClaimSchema,
   LockType,
@@ -89,6 +90,7 @@ import { createMigrationSource } from "../../../main/typescript/database/knex-mi
 import { knexLocalInstance } from "../../../main/typescript/database/knexfile";
 import { knexRemoteInstance } from "../../../main/typescript/database/knexfile-remote";
 import { MonitorService } from "../../../main/typescript/services/monitoring/monitor";
+import { LockAssertionExpirationError } from "../../../main/typescript/core/errors/satp-service-errors";
 
 const logLevel: LogLevelDesc = "DEBUG";
 
@@ -122,6 +124,7 @@ let localRepository: ILocalLogRepository;
 let remoteRepository: IRemoteLogRepository;
 let auditRepository: IAuditEntryRepository;
 let dbLogger: GatewayPersistence;
+let dateNowSpy: jest.SpyInstance | undefined;
 let persistLogEntrySpy: jest.SpyInstance;
 let bridgeManager: BridgeManagerClientInterface;
 
@@ -164,6 +167,12 @@ beforeAll(async () => {
     return {
       getNetworkType() {
         return LedgerType.Besu2X;
+      },
+      async lockAsset() {
+        return {
+          receipt: "MOCK_LOCK_RECEIPT",
+          proof: "MOCK_LOCK_PROOF",
+        };
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
@@ -256,6 +265,8 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
+  dateNowSpy?.mockRestore();
+  dateNowSpy = undefined;
   persistLogEntrySpy.mockClear();
 });
 
@@ -725,7 +736,21 @@ describe("SATP Services Testing", () => {
     );
     mockSession.getClientSessionData().lockAssertionClaimFormat!.format =
       ClaimFormat.DEFAULT;
-    mockSession.getClientSessionData().lockExpirationTime = BigInt(1000);
+    const lockExpirationTime = BigInt(5 * 60 * 1000);
+    const currentTime = Date.now();
+    const clientSessionData = mockSession.getClientSessionData();
+    const serverSessionData = mockSession.getServerSessionData();
+    clientSessionData.lockExpirationTime = lockExpirationTime;
+    serverSessionData.lockExpirationTime = lockExpirationTime;
+    dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(currentTime);
+
+    await satpClientService2.lockAsset(mockSession);
+    const expectedExpiration = BigInt(currentTime) + lockExpirationTime;
+    expect(clientSessionData.lockAssertionExpiration).toBe(expectedExpiration);
+    dateNowSpy.mockRestore();
+    dateNowSpy = undefined;
+
+    persistLogEntrySpy.mockClear();
 
     lockAssertionRequestMessage =
       (await satpClientService2.lockAssertionRequest(
@@ -753,12 +778,65 @@ describe("SATP Services Testing", () => {
     expect(lockAssertionRequestMessage.common?.sequenceNumber).toBeDefined();
     expect(lockAssertionRequestMessage.lockAssertionClaim).toBeDefined();
     expect(lockAssertionRequestMessage.lockAssertionClaimFormat).toBeDefined();
-    expect(lockAssertionRequestMessage.lockAssertionExpiration).toBeDefined();
+    expect(lockAssertionRequestMessage.lockAssertionExpiration).toBe(
+      expectedExpiration,
+    );
     expect(lockAssertionRequestMessage.clientTransferNumber).toBeDefined();
     expect(lockAssertionRequestMessage.clientSignature).toBeDefined();
     expect(
       lockAssertionRequestMessage.common?.hashPreviousMessage,
     ).toBeDefined();
+  });
+  it("Service2Server rejects expired lock assertions", async () => {
+    const expiration = lockAssertionRequestMessage.lockAssertionExpiration;
+    dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(Number(expiration));
+
+    const validation = satpServerService2.checkLockAssertionRequest(
+      lockAssertionRequestMessage,
+      mockSession,
+    );
+
+    await expect(validation).rejects.toBeInstanceOf(
+      LockAssertionExpirationError,
+    );
+  });
+  it("Service2Server rejects expiration beyond negotiated window", async () => {
+    const serverSessionData = mockSession.getServerSessionData();
+    const negotiatedExpirationTime = serverSessionData.lockExpirationTime;
+    const expiration = lockAssertionRequestMessage.lockAssertionExpiration;
+    serverSessionData.lockExpirationTime = BigInt(1);
+    dateNowSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValue(Number(expiration - BigInt(2)));
+
+    try {
+      const validation = satpServerService2.checkLockAssertionRequest(
+        lockAssertionRequestMessage,
+        mockSession,
+      );
+
+      await expect(validation).rejects.toBeInstanceOf(
+        LockAssertionExpirationError,
+      );
+    } finally {
+      serverSessionData.lockExpirationTime = negotiatedExpirationTime;
+    }
+  });
+  it("Service2Server emits a SATP lock expiration error response", async () => {
+    const error = new LockAssertionExpirationError(
+      "Stage2ServerService#checkLockAssertionRequest()",
+      "lock assertion already expired",
+    );
+
+    const response = await satpServerService2.lockAssertionErrorResponse(
+      error,
+      mockSession,
+    );
+
+    expect(response.common?.error).toBe(true);
+    expect(response.common?.errorCode).toBe(
+      SATPErrorType.LOCK_ASSERTION_EXPIRATION_ERROR,
+    );
   });
   it("Service2Server checkLockAssertionRequest", async () => {
     expect(satpServerService2).toBeDefined();


### PR DESCRIPTION
<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

Implement lock assertion expiration handling for SATP Hermes.

The client gateway now calculates the lock assertion expiration from the current time and the lock duration negotiated during session setup. The server gateway rejects lock assertions that have already expired or exceed the negotiated expiration window.

Lock expiration failures are converted through the client-facing SATP error model introduced by #4270 and returned as signed protocol error responses using `LOCK_ASSERTION_EXPIRATION_ERROR`.

Unit coverage verifies:

- Lock expiration calculation
- Rejection of expired assertions
- Rejection of assertions beyond the negotiated expiration window
- Client-facing SATP error responses
- Reliable cleanup of mocked system time

This PR supersedes #4285. The original contributor's authorship is preserved through the `Co-authored-by` trailer in the commit.

## Related issue

Closes #3783  
Supersedes #4285

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.