### PR TITLE
fix(satp-hermes): use bigint for ERC-6909/ERC-721 uniqueDescriptor

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/service-utils.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/service-utils.ts
@@ -81,6 +81,20 @@ function toSafeNumber(value: bigint | string, fieldName: string): number {
 }
 
 /**
+ * Converts a bigint or numeric string to a bigint, rethrowing with the field
+ * name and value if it is not a valid integer representation.
+ */
+function toSafeBigInt(value: bigint | string, fieldName: string): bigint {
+  try {
+    return BigInt(value);
+  } catch (err) {
+    throw new Error(
+      `Cannot convert ${fieldName} "${value}" to a BigInt: ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
  * Converts internal fungible asset representation to Protocol Buffer format.
  *
  * @description
@@ -304,13 +318,13 @@ export function protoToAsset(asset: ProtoAsset, networkId: NetworkId): Asset {
       "amount",
     ) as Amount;
     if (asset.uniqueDescriptor) {
-      (assetObj as FungibleAsset).uniqueDescriptor = toSafeNumber(
+      (assetObj as FungibleAsset).uniqueDescriptor = toSafeBigInt(
         asset.uniqueDescriptor,
         "uniqueDescriptor",
       ) as UniqueTokenID;
     }
   } else if (asset.tokenType == TokenType.NONSTANDARD_NONFUNGIBLE) {
-    (assetObj as NonFungibleAsset).uniqueDescriptor = toSafeNumber(
+    (assetObj as NonFungibleAsset).uniqueDescriptor = toSafeBigInt(
       asset.amount,
       "amount",
     ) as UniqueTokenID;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/besu-leaf.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/besu-leaf.ts
@@ -1118,7 +1118,7 @@ export class BesuLeaf
               contractAddress: token.contractAddress,
               type: Number(token.tokenType),
               owner: token.owner,
-              uniqueDescriptor: Number(token.amount) as UniqueTokenID,
+              uniqueDescriptor: BigInt(token.amount) as UniqueTokenID,
               network: this.networkIdentification,
               ercTokenStandard: Number(token.ercTokenStandard),
             } as EvmNonFungibleAsset;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/ethereum-leaf.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/leafs/ethereum-leaf.ts
@@ -1415,7 +1415,7 @@ export class EthereumLeaf
               contractAddress: token.contractAddress,
               type: Number(token.tokenType),
               owner: token.owner,
-              uniqueDescriptor: Number(token.amount) as UniqueTokenID,
+              uniqueDescriptor: BigInt(token.amount) as UniqueTokenID,
               network: this.networkIdentification,
               ercTokenStandard: Number(token.ercTokenStandard),
             } as EvmNonFungibleAsset;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/ontology/assets/asset.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/ontology/assets/asset.ts
@@ -114,7 +114,7 @@ export interface Asset {
 
 export type Brand<K, T> = K & { __brand: T };
 export type Amount = Brand<number, "Amount">;
-export type UniqueTokenID = Brand<number, "UniqueTokenID">;
+export type UniqueTokenID = Brand<bigint, "UniqueTokenID">;
 
 export interface FungibleAsset extends Asset {
   amount: Amount;
@@ -128,7 +128,7 @@ export interface FungibleAsset extends Asset {
  * MultiTokenAsset always carries the chain-native token type ID so the bridge
  * can dispatch the correct uniqueDescriptor overload on lock/mint/burn/assign.
  * The uniqueDescriptor here is the uint256 token type ID from the on-chain
- * contract, carried as a branded number (not the SATP-internal token_id).
+ * contract, carried as a branded bigint (not the SATP-internal token_id).
  */
 export interface MultiTokenAsset extends FungibleAsset {
   uniqueDescriptor: UniqueTokenID;

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/satp-bridge-execution-layer-implementation.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/cross-chain-mechanisms/bridge/satp-bridge-execution-layer-implementation.ts
@@ -330,9 +330,7 @@ export class SATPBridgeExecutionLayerImpl implements SATPBridgeExecutionLayer {
         } else if (instanceOfNonFungibleAsset(asset)) {
           response = await (bridgeEndPoint as BridgeLeafNonFungible).lockAsset(
             asset.id,
-            Number(
-              (asset as NonFungibleAsset).uniqueDescriptor,
-            ) as UniqueTokenID,
+            (asset as NonFungibleAsset).uniqueDescriptor,
           );
         }
         break;
@@ -352,12 +350,7 @@ export class SATPBridgeExecutionLayerImpl implements SATPBridgeExecutionLayer {
         } else if (instanceOfNonFungibleAsset(asset)) {
           response = await (
             bridgeEndPoint as BridgeLeafNonFungible
-          ).unlockAsset(
-            asset.id,
-            Number(
-              (asset as NonFungibleAsset).uniqueDescriptor,
-            ) as UniqueTokenID,
-          );
+          ).unlockAsset(asset.id, (asset as NonFungibleAsset).uniqueDescriptor);
         }
         break;
       case SATPStageOperations.MINT:

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/environments/besu-test-environment.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/environments/besu-test-environment.ts
@@ -645,7 +645,7 @@ export class BesuTestEnvironment {
       keychainId: inUseContractKeyChainId,
       invocationType: BesuContractInvocationType.Send,
       methodName: "approve",
-      params: [wrapperAddress, Number(assetAttribute)],
+      params: [wrapperAddress, BigInt(assetAttribute)],
       signingCredential: {
         ethAccount: this.firstHighNetWorthAccount,
         secret: this.besuKeyPair.privateKey,
@@ -753,7 +753,7 @@ export class BesuTestEnvironment {
    */
   public async mintMultiTokens(
     amount: string,
-    tokenTypeId: number,
+    tokenTypeId: bigint | string,
   ): Promise<void> {
     const responseMint = await this.connector.invokeContract({
       contractName:
@@ -783,7 +783,7 @@ export class BesuTestEnvironment {
   public async checkMultiTokenBalance(
     contractAddress: string,
     account: string,
-    tokenTypeId: number,
+    tokenTypeId: bigint | string,
     expectedAmount: string,
     signingCredential: Web3SigningCredential,
   ): Promise<void> {

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/environments/ethereum-test-environment.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/environments/ethereum-test-environment.ts
@@ -557,7 +557,7 @@ export class EthereumTestEnvironment {
    */
   public async mintMultiTokens(
     amount: string,
-    tokenTypeId: number,
+    tokenTypeId: bigint | string,
   ): Promise<void> {
     const responseMint = await this.connector.invokeContract({
       contract: {
@@ -588,7 +588,7 @@ export class EthereumTestEnvironment {
   public async checkMultiTokenBalance(
     contractAddress: string,
     account: string,
-    tokenTypeId: number,
+    tokenTypeId: bigint | string,
     expectedAmount: string,
     signingCredential: Web3SigningCredential,
   ): Promise<void> {
@@ -714,7 +714,7 @@ export class EthereumTestEnvironment {
       },
       invocationType: EthContractInvocationType.Send,
       methodName: "approve",
-      params: [wrapperAddress, Number(assetAttribute)],
+      params: [wrapperAddress, BigInt(assetAttribute)],
       web3SigningCredential: {
         ethAccount: WHALE_ACCOUNT_ADDRESS,
         secret: "",

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/besu-leaf.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/besu-leaf.test.ts
@@ -30,7 +30,7 @@ let ontologyManager: OntologyManager;
 let asset: EvmFungibleAsset;
 let nonFungibleAsset: EvmNonFungibleAsset;
 
-const uniqueTokenId1: string = "1001";
+const uniqueTokenId1: string = "9007199254740993";
 const uniqueTokenId2: string = "1002";
 
 const monitorService = MonitorService.createOrGetMonitorService({
@@ -466,7 +466,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
       owner: besuEnv.nonFungibleDefaultAsset.owner,
       contractName: besuEnv.nonFungibleDefaultAsset.contractName,
       contractAddress: besuEnv.nonFungibleDefaultAsset.contractAddress!,
-      uniqueDescriptor: Number(uniqueTokenId1) as UniqueTokenID,
+      uniqueDescriptor: BigInt(uniqueTokenId1) as UniqueTokenID,
       network: {
         id: BesuTestEnvironment.BESU_NETWORK_ID,
         ledgerType: LedgerType.Besu2X,
@@ -517,7 +517,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
 
     const response = await besuLeaf.lockAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -536,7 +536,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
 
     const response2 = (await besuLeaf.getAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     )) as EvmNonFungibleAsset;
     expect(response2).toBeDefined();
     expect(response2.id).toBe(nonFungibleAsset.id);
@@ -547,7 +547,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
       besuEnv.nonFungibleDefaultAsset.contractName,
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     log.info(`Locked token ${uniqueTokenId1} successfully`);
 
@@ -584,7 +584,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
 
     const response = await besuLeaf.unlockAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -615,7 +615,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
       besuEnv.nonFungibleDefaultAsset.contractName,
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      0 as UniqueTokenID,
+      0n as UniqueTokenID,
     );
     log.info(`Unlocked token ${uniqueTokenId1} successfully`);
 
@@ -652,7 +652,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
     );
     const response = await besuLeaf.lockAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -661,7 +661,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
 
     const response2 = await besuLeaf.burnAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response2).toBeDefined();
     expect(response2.transactionId).toBeDefined();
@@ -682,7 +682,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
       besuEnv.nonFungibleDefaultAsset.contractName,
     );
     expect(response3.uniqueDescriptor as UniqueTokenID).toBe(
-      0 as UniqueTokenID,
+      0n as UniqueTokenID,
     );
 
     await besuEnv.checkBalance(
@@ -711,7 +711,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
   it("Should Mint a token", async () => {
     const response = await besuLeaf.mintAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -720,7 +720,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
 
     const response2 = (await besuLeaf.getAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     )) as EvmNonFungibleAsset;
     expect(response2).toBeDefined();
     expect(response2.id).toBe(nonFungibleAsset.id);
@@ -730,7 +730,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
       besuEnv.getTestNonFungibleContractAddress(),
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     );
     log.info(`Minted token ${uniqueTokenId2} successfully`);
 
@@ -751,7 +751,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
     const response = await besuLeaf.assignAsset(
       nonFungibleAsset.id,
       nonFungibleAsset.owner,
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -769,7 +769,7 @@ describe("Besu Leaf Test with Non Fungible Tokens", () => {
       besuEnv.getTestNonFungibleContractAddress(),
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      0 as UniqueTokenID,
+      0n as UniqueTokenID,
     );
     log.info(
       `Assigned token ${uniqueTokenId2} successfully from wrapper account`,

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/erc6909-ethereum-leaf.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/erc6909-ethereum-leaf.test.ts
@@ -22,9 +22,12 @@ import {
 } from "../../../../main/typescript/cross-chain-mechanisms/bridge/ontology/assets/asset";
 import { SupportedContractTypes } from "../../environments/ethereum-test-environment";
 
-// ERC-6909 token type IDs used across all tests in this suite
-const TOKEN_TYPE_A = 42 as UniqueTokenID;
-const TOKEN_TYPE_B = 99 as UniqueTokenID;
+// ERC-6909 token type IDs used across all tests in this suite.
+// TOKEN_TYPE_A exceeds Number.MAX_SAFE_INTEGER (2^53 - 1) to exercise the
+// bigint path end-to-end and catch any regression to a lossy Number()
+// conversion.
+const TOKEN_TYPE_A = 9007199254740993n as UniqueTokenID;
+const TOKEN_TYPE_B = 99n as UniqueTokenID;
 
 let ontologyManager: OntologyManager;
 let multiTokenAsset: EvmMultiTokenAsset;
@@ -80,7 +83,7 @@ beforeAll(async () => {
     // Mint 200 tokens of TOKEN_TYPE_A to the whale account.
     // The deployer automatically holds BRIDGE_ROLE on SATMultiTokenContract
     // so the mint call goes through without an explicit role grant.
-    await ethereumEnv.mintMultiTokens("200", Number(TOKEN_TYPE_A));
+    await ethereumEnv.mintMultiTokens("200", TOKEN_TYPE_A);
   }
 }, TIMEOUT);
 
@@ -182,14 +185,14 @@ describe("ERC6909 Multi-Token Ethereum Leaf Test", () => {
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       wrapperAddress,
-      Number(TOKEN_TYPE_A),
+      TOKEN_TYPE_A,
       "100",
       ethereumEnv.getTestOwnerSigningCredential(),
     );
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       WHALE_ACCOUNT_ADDRESS,
-      Number(TOKEN_TYPE_A),
+      TOKEN_TYPE_A,
       "100",
       ethereumEnv.getTestOwnerSigningCredential(),
     );
@@ -213,14 +216,14 @@ describe("ERC6909 Multi-Token Ethereum Leaf Test", () => {
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       wrapperAddress,
-      Number(TOKEN_TYPE_A),
+      TOKEN_TYPE_A,
       "0",
       ethereumEnv.getTestOwnerSigningCredential(),
     );
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       WHALE_ACCOUNT_ADDRESS,
-      Number(TOKEN_TYPE_A),
+      TOKEN_TYPE_A,
       "200",
       ethereumEnv.getTestOwnerSigningCredential(),
     );
@@ -252,7 +255,7 @@ describe("ERC6909 Multi-Token Ethereum Leaf Test", () => {
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       wrapperAddress,
-      Number(TOKEN_TYPE_A),
+      TOKEN_TYPE_A,
       "0",
       ethereumEnv.getTestOwnerSigningCredential(),
     );
@@ -276,7 +279,7 @@ describe("ERC6909 Multi-Token Ethereum Leaf Test", () => {
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       wrapperAddress,
-      Number(TOKEN_TYPE_B),
+      TOKEN_TYPE_B,
       "50",
       ethereumEnv.getTestOwnerSigningCredential(),
     );
@@ -300,14 +303,14 @@ describe("ERC6909 Multi-Token Ethereum Leaf Test", () => {
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       wrapperAddress,
-      Number(TOKEN_TYPE_B),
+      TOKEN_TYPE_B,
       "0",
       ethereumEnv.getTestOwnerSigningCredential(),
     );
     await ethereumEnv.checkMultiTokenBalance(
       ethereumEnv.getTestMultiTokenContractAddress(),
       WHALE_ACCOUNT_ADDRESS,
-      Number(TOKEN_TYPE_B),
+      TOKEN_TYPE_B,
       "50",
       ethereumEnv.getTestOwnerSigningCredential(),
     );

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/ethereum-leaf.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/bridge/ethereum-leaf.test.ts
@@ -30,7 +30,7 @@ let ontologyManager: OntologyManager;
 let asset: EvmFungibleAsset;
 let nonFungibleAsset: EvmNonFungibleAsset;
 
-const uniqueTokenId1: string = "1001";
+const uniqueTokenId1: string = "9007199254740993";
 const uniqueTokenId2: string = "1002";
 
 const monitorService = MonitorService.createOrGetMonitorService({
@@ -88,7 +88,10 @@ beforeAll(async () => {
     await ethereumEnv.deployAndSetupContracts(ClaimFormat.DEFAULT);
 
     await ethereumEnv.mintTokens("100", TokenType.NONSTANDARD_FUNGIBLE);
-    await ethereumEnv.mintTokens("1001", TokenType.NONSTANDARD_NONFUNGIBLE);
+    await ethereumEnv.mintTokens(
+      uniqueTokenId1,
+      TokenType.NONSTANDARD_NONFUNGIBLE,
+    );
   }
 }, TIMEOUT);
 
@@ -485,7 +488,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
       owner: WHALE_ACCOUNT_ADDRESS,
       contractName: ethereumEnv.nonFungibleDefaultAsset.contractName,
       contractAddress: ethereumEnv.nonFungibleDefaultAsset.contractAddress!,
-      uniqueDescriptor: Number(uniqueTokenId1) as UniqueTokenID,
+      uniqueDescriptor: BigInt(uniqueTokenId1) as UniqueTokenID,
       network: {
         id: EthereumTestEnvironment.ETH_NETWORK_ID,
         ledgerType: LedgerType.Ethereum,
@@ -523,7 +526,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
   it("Should Approve a token", async () => {
     await ethereumEnv.approveAssets(
       ethereumLeaf.getWrapperContract(TokenType.NONSTANDARD_NONFUNGIBLE),
-      "1001",
+      uniqueTokenId1,
       TokenType.NONSTANDARD_NONFUNGIBLE,
     );
   });
@@ -531,7 +534,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
   it("Should Lock a token", async () => {
     const response = await ethereumLeaf.lockAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -539,7 +542,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
 
     const response2 = (await ethereumLeaf.getAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     )) as EvmNonFungibleAsset;
     expect(response2).toBeDefined();
     expect(response2.id).toBe(nonFungibleAsset.id);
@@ -552,7 +555,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
       ethereumEnv.getTestNonFungibleContractName(),
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     log.info(`Locked token${uniqueTokenId1} successfully`);
 
@@ -584,7 +587,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
   it("Should Unlock a token", async () => {
     const response = await ethereumLeaf.unlockAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -604,7 +607,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
       ethereumEnv.getTestNonFungibleContractName(),
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      0 as UniqueTokenID,
+      0n as UniqueTokenID,
     );
     log.info(`Unlocked token ${uniqueTokenId1} successfully`);
 
@@ -641,7 +644,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
     );
     const response = await ethereumLeaf.lockAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -650,7 +653,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
 
     const response2 = await ethereumLeaf.burnAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId1) as UniqueTokenID,
+      BigInt(uniqueTokenId1) as UniqueTokenID,
     );
     expect(response2).toBeDefined();
     expect(response2.transactionId).toBeDefined();
@@ -671,7 +674,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
       ethereumEnv.nonFungibleDefaultAsset.contractName,
     );
     expect(response3.uniqueDescriptor as UniqueTokenID).toBe(
-      0 as UniqueTokenID,
+      0n as UniqueTokenID,
     );
 
     await ethereumEnv.checkBalance(
@@ -700,7 +703,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
   it("Should Mint a token", async () => {
     const response = await ethereumLeaf.mintAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -709,7 +712,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
 
     const response2 = (await ethereumLeaf.getAsset(
       nonFungibleAsset.id,
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     )) as EvmNonFungibleAsset;
     expect(response2).toBeDefined();
     expect(response2.id).toBe(nonFungibleAsset.id);
@@ -719,7 +722,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
       ethereumEnv.getTestNonFungibleContractAddress().toLowerCase(),
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     );
     log.info(`Minted token ${uniqueTokenId2} successfully`);
 
@@ -740,7 +743,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
     const response = await ethereumLeaf.assignAsset(
       nonFungibleAsset.id,
       nonFungibleAsset.owner,
-      Number(uniqueTokenId2) as UniqueTokenID,
+      BigInt(uniqueTokenId2) as UniqueTokenID,
     );
     expect(response).toBeDefined();
     expect(response.transactionId).toBeDefined();
@@ -758,7 +761,7 @@ describe("Ethereum Leaf Non Fungible Test", () => {
       ethereumEnv.getTestNonFungibleContractAddress(),
     );
     expect(response2.uniqueDescriptor as UniqueTokenID).toBe(
-      0 as UniqueTokenID,
+      0n as UniqueTokenID,
     );
     log.info(
       `Assigned token ${uniqueTokenId2} successfully from wrapper account`,

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway/satp-e2e-transfer-2-gateway-with-api-server.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/gateway/satp-e2e-transfer-2-gateway-with-api-server.test.ts
@@ -121,7 +121,7 @@ beforeEach(() => {
     });
 }, TIMEOUT);
 
-const ERC6909_TOKEN_TYPE_ID = 42;
+const ERC6909_TOKEN_TYPE_ID = 42n;
 
 beforeAll(async () => {
   // Fabric setup skipped — all Fabric describe blocks are describe.skip


### PR DESCRIPTION
## Description

`UniqueTokenID` (used for ERC-6909/ERC-721 `uniqueDescriptor`) was branded as `number`. Since on-chain token IDs are `uint256`, any value above `Number.MAX_SAFE_INTEGER` silently loses precision when passed through `Number()`, corrupting the token ID used for cross-chain asset transfer.

This PR rebrands `UniqueTokenID` as `bigint` and fixes the affected `Number()` conversions in the bridge execution layer, the Besu/Ethereum EVM leafs, and their integration tests, so large on-chain token IDs are no longer truncated.

Assisted-by: anthropic:claude-sonnet-5

## Related issue

Fixes #4703

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
