### PR TITLE
docs: address cleanup findings for #4596

### DIFF
--- a/.github/workflows/test_weaver-asset-exchange-besu.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-besu.yaml
@@ -403,3 +403,33 @@ jobs:
           fi
         working-directory: weaver/samples/besu/besu-cli
 
+
+  # Single rollup gate for all Besu asset-exchange jobs above. Branch protection
+  # requires ONLY this context (asset-exchange-besu / asset-exchange-besu-success)
+  # instead of the per-matrix-leg contexts. Because the matrix jobs skip at the
+  # job level when paths-filter finds no relevant change, their per-leg contexts
+  # are never emitted and would otherwise leave a required check pending forever.
+  # This job runs with `if: always()` so it always reports a status; a `skipped`
+  # dependency (including a matrix job that never spawned any legs) is treated as
+  # passing, and only `failure`/`cancelled` fail the gate.
+  asset-exchange-besu-success:
+    needs:
+      - check_code_changed
+      - asset-exchange-besu
+      - asset-exchange-besu-local
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all besu asset-exchange jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed        = ${{ needs.check_code_changed.result }}"
+          echo "  asset-exchange-besu       = ${{ needs.asset-exchange-besu.result }}"
+          echo "  asset-exchange-besu-local = ${{ needs.asset-exchange-besu-local.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more Besu asset-exchange jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All Besu asset-exchange jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-asset-exchange-corda.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-corda.yaml
@@ -351,3 +351,32 @@ jobs:
               exit 1
           fi
         working-directory: weaver/samples/corda/corda-simple-application
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  asset-exchange-corda-success:
+    needs:
+      - check_code_changed
+      - asset-exchange-corda
+      - asset-exchange-corda-local
+      - house-token-exchange-corda
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed         = ${{ needs.check_code_changed.result }}"
+          echo "  asset-exchange-corda       = ${{ needs.asset-exchange-corda.result }}"
+          echo "  asset-exchange-corda-local = ${{ needs.asset-exchange-corda-local.result }}"
+          echo "  house-token-exchange-corda = ${{ needs.house-token-exchange-corda.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-asset-exchange-fabric.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-fabric.yaml
@@ -208,3 +208,30 @@ jobs:
               exit 1
           fi
         working-directory: weaver/samples/fabric/fabric-cli
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  asset-exchange-fabric-success:
+    needs:
+      - check_code_changed
+      - asset-exchange-fabric
+      - asset-exchange-fabric-local
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed          = ${{ needs.check_code_changed.result }}"
+          echo "  asset-exchange-fabric       = ${{ needs.asset-exchange-fabric.result }}"
+          echo "  asset-exchange-fabric-local = ${{ needs.asset-exchange-fabric-local.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-asset-transfer.yaml
+++ b/.github/workflows/test_weaver-asset-transfer.yaml
@@ -1376,3 +1376,30 @@ jobs:
       - if: failure()
         name: DEBUG Logs - iin agent n2 org1
         run: cat weaver/core/identity-management/iin-agent/iinagent-n2.out
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  asset-transfer-success:
+    needs:
+      - check_code_changed
+      - asset-transfer
+      - asset-transfer-local
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed   = ${{ needs.check_code_changed.result }}"
+          echo "  asset-transfer       = ${{ needs.asset-transfer.result }}"
+          echo "  asset-transfer-local = ${{ needs.asset-transfer-local.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-corda-pkgs.yaml
+++ b/.github/workflows/test_weaver-corda-pkgs.yaml
@@ -97,3 +97,30 @@ jobs:
     - name: Run Corda SDK Tests (Local)
       run: make test
       working-directory: weaver/sdks/corda
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  corda-pkgs-success:
+    needs:
+      - check_code_changed
+      - unit_test_interop_cordapp
+      - unit_test_corda_sdk
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed        = ${{ needs.check_code_changed.result }}"
+          echo "  unit_test_interop_cordapp = ${{ needs.unit_test_interop_cordapp.result }}"
+          echo "  unit_test_corda_sdk       = ${{ needs.unit_test_corda_sdk.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-data-sharing.yaml
+++ b/.github/workflows/test_weaver-data-sharing.yaml
@@ -1285,3 +1285,32 @@ jobs:
       - if: failure()
         name: DEBUG Logs - iin agent n2 org1
         run: cat weaver/core/identity-management/iin-agent/iinagent-n2.out
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  data-sharing-success:
+    needs:
+      - check_code_changed
+      - data-sharing
+      - data-sharing-docker-local
+      - data-sharing-local
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed        = ${{ needs.check_code_changed.result }}"
+          echo "  data-sharing              = ${{ needs.data-sharing.result }}"
+          echo "  data-sharing-docker-local = ${{ needs.data-sharing-docker-local.result }}"
+          echo "  data-sharing-local        = ${{ needs.data-sharing-local.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-docker-build.yaml
+++ b/.github/workflows/test_weaver-docker-build.yaml
@@ -220,3 +220,38 @@ jobs:
       - name: Build Image
         run: make build-image-local
         working-directory: weaver/core/identity-management/iin-agent
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  docker-build-success:
+    needs:
+      - check_code_changed
+      - build_docker_relay
+      - build_docker_fabric_driver_local
+      - build_docker_fabric_driver_packages
+      - build_docker_corda_driver_local
+      - build_docker_corda_driver_packages
+      - build_docker_iin_agent_local
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed                  = ${{ needs.check_code_changed.result }}"
+          echo "  build_docker_relay                  = ${{ needs.build_docker_relay.result }}"
+          echo "  build_docker_fabric_driver_local    = ${{ needs.build_docker_fabric_driver_local.result }}"
+          echo "  build_docker_fabric_driver_packages = ${{ needs.build_docker_fabric_driver_packages.result }}"
+          echo "  build_docker_corda_driver_local     = ${{ needs.build_docker_corda_driver_local.result }}"
+          echo "  build_docker_corda_driver_packages  = ${{ needs.build_docker_corda_driver_packages.result }}"
+          echo "  build_docker_iin_agent_local        = ${{ needs.build_docker_iin_agent_local.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-fabric-fabric-satp.yaml
+++ b/.github/workflows/test_weaver-fabric-fabric-satp.yaml
@@ -197,3 +197,28 @@ jobs:
       - name: DEBUG Logs - fabric n1 and n2 driver
         if: failure()
         run: cat weaver/core/drivers/fabric-driver/fdriver.out
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  fabric-fabric-satp-success:
+    needs:
+      - check_code_changed
+      - fabric-fabric-satp-local
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed       = ${{ needs.check_code_changed.result }}"
+          echo "  fabric-fabric-satp-local = ${{ needs.fabric-fabric-satp-local.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-go.yaml
+++ b/.github/workflows/test_weaver-go.yaml
@@ -18,12 +18,6 @@ permissions:
   contents: read
 
 jobs:
-
-  debug_event_type:
-    runs-on: ubuntu-22.04
-    steps:
-      - run: echo "${{ github.event_name }}"
-     
   check_code_changed:
     outputs:
       interopcc_changed: ${{ steps.changes.outputs.interopcc_changed }}
@@ -349,3 +343,50 @@ jobs:
     - name: Test
       run: GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn CACTI_ROOT=$GITHUB_WORKSPACE go test -v .
       working-directory: weaver/sdks/fabric/go-sdk/membershipmanager
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  go-success:
+    needs:
+      - check_code_changed
+      - unit_test_interopcc
+      - unit_test_assetmgmt
+      - build_test_libs_utils
+      - build_test_libs_assetexchange
+      - unit_test_sdk
+      - build_test_cli
+      - unit_test_simplestate
+      - unit_test_satpsimpleasset
+      - unit_test_simpleasset
+      - unit_test_simpleassetandinterop
+      - unit_test_simpleassettransfer
+      - unit_test_sdk_membership
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed              = ${{ needs.check_code_changed.result }}"
+          echo "  unit_test_interopcc             = ${{ needs.unit_test_interopcc.result }}"
+          echo "  unit_test_assetmgmt             = ${{ needs.unit_test_assetmgmt.result }}"
+          echo "  build_test_libs_utils           = ${{ needs.build_test_libs_utils.result }}"
+          echo "  build_test_libs_assetexchange   = ${{ needs.build_test_libs_assetexchange.result }}"
+          echo "  unit_test_sdk                   = ${{ needs.unit_test_sdk.result }}"
+          echo "  build_test_cli                  = ${{ needs.build_test_cli.result }}"
+          echo "  unit_test_simplestate           = ${{ needs.unit_test_simplestate.result }}"
+          echo "  unit_test_satpsimpleasset       = ${{ needs.unit_test_satpsimpleasset.result }}"
+          echo "  unit_test_simpleasset           = ${{ needs.unit_test_simpleasset.result }}"
+          echo "  unit_test_simpleassetandinterop = ${{ needs.unit_test_simpleassetandinterop.result }}"
+          echo "  unit_test_simpleassettransfer   = ${{ needs.unit_test_simpleassettransfer.result }}"
+          echo "  unit_test_sdk_membership        = ${{ needs.unit_test_sdk_membership.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-node-pkgs.yaml
+++ b/.github/workflows/test_weaver-node-pkgs.yaml
@@ -157,3 +157,35 @@ jobs:
       - name: Build
         run: mkdocs build
         working-directory: docs
+
+  # Single rollup gate for all Weaver node-package jobs above. Branch protection
+  # requires ONLY this context (node-pkgs / node-pkgs-success) instead of the
+  # per-matrix-leg contexts. Because the matrix jobs skip at the job level when
+  # paths-filter finds no relevant change, their per-leg contexts are never
+  # emitted and would otherwise leave a required check pending forever. This job
+  # runs with `if: always()` so it always reports a status; a `skipped`
+  # dependency (including a matrix job that never spawned any legs) is treated as
+  # passing, and only `failure`/`cancelled` fail the gate.
+  node-pkgs-success:
+    needs:
+      - check_code_changed
+      - unit_test_weaver_node_sdk_local
+      - unit_test_iin_agent_local
+      - build-docs
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all node-pkgs jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed              = ${{ needs.check_code_changed.result }}"
+          echo "  unit_test_weaver_node_sdk_local = ${{ needs.unit_test_weaver_node_sdk_local.result }}"
+          echo "  unit_test_iin_agent_local       = ${{ needs.unit_test_iin_agent_local.result }}"
+          echo "  build-docs                      = ${{ needs.build-docs.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more Weaver node-package jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All Weaver node-package jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-pre-release.yaml
+++ b/.github/workflows/test_weaver-pre-release.yaml
@@ -171,3 +171,30 @@ jobs:
       
       - name: Check if changes are committed
         run: (git status | grep "nothing to commit, working tree clean") || (echo "go-gen-checksum not called before release commit" && exit 1)
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  pre-release-success:
+    needs:
+      - check_release
+      - test_weaver_pre-release
+      - test_weaver_go_pre-release
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_release              = ${{ needs.check_release.result }}"
+          echo "  test_weaver_pre-release    = ${{ needs.test_weaver_pre-release.result }}"
+          echo "  test_weaver_go_pre-release = ${{ needs.test_weaver_go_pre-release.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/.github/workflows/test_weaver-relay.yaml
+++ b/.github/workflows/test_weaver-relay.yaml
@@ -218,3 +218,34 @@ jobs:
             sleep 30
             cargo run --bin client-tls 9085 localhost:9085/Dummy_Network/abc:abc:abc:abc
         working-directory: weaver/core/relay
+
+  # Single rollup gate for all jobs above. Branch protection requires ONLY this
+  # context instead of the individual job contexts, so a job that legitimately
+  # skips (paths-filter found no relevant change) does not leave a required
+  # check pending forever. `if: always()` makes it always report a status; a
+  # `skipped` dependency is treated as passing, only `failure`/`cancelled` fail.
+  relay-success:
+    needs:
+      - check_code_changed
+      - unit_test_relay_local
+      - unit_test_relay_tls_local
+      - unit_test_relay
+      - unit_test_relay_tls
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report status of all jobs
+        run: |
+          echo "Status of upstream jobs:"
+          echo "  check_code_changed        = ${{ needs.check_code_changed.result }}"
+          echo "  unit_test_relay_local     = ${{ needs.unit_test_relay_local.result }}"
+          echo "  unit_test_relay_tls_local = ${{ needs.unit_test_relay_tls_local.result }}"
+          echo "  unit_test_relay           = ${{ needs.unit_test_relay.result }}"
+          echo "  unit_test_relay_tls       = ${{ needs.unit_test_relay_tls.result }}"
+      - name: Fail if any job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::One or more jobs failed or were cancelled."
+          exit 1
+      - name: All jobs passed
+        run: echo "All jobs succeeded or were skipped."

--- a/docs/docs/references/index.md
+++ b/docs/docs/references/index.md
@@ -1,0 +1,15 @@
+# References
+
+The following resources provide additional information about Hyperledger Cacti, blockchain interoperability research, and practical implementations.
+
+## Presentations and Videos
+
+Explore [Hyperledger Cacti presentations and videos on YouTube](https://www.youtube.com/results?search_query=hyperledger+cacti) for project demonstrations, technical discussions, and community presentations.
+
+## Academic Research
+
+The [Interoperability Theory repository](https://github.com/hyperledger-cacti/interoperability-theory) collects research and supporting materials related to distributed ledger interoperability.
+
+## Demonstrations and Sample Applications
+
+The [Cacti Demos repository](https://github.com/hyperledger-cacti/cacti-demos) contains runnable examples and demonstration applications built with Hyperledger Cacti.

--- a/docs/docs/satp-hermes/index.md
+++ b/docs/docs/satp-hermes/index.md
@@ -1,0 +1,1 @@
+--8<-- "packages/cactus-plugin-satp-hermes/docs/architecture/satp-hermes.md"

--- a/docs/docs/start-here.md
+++ b/docs/docs/start-here.md
@@ -20,6 +20,7 @@ set of reference links defined at the bottom of that file.
 [build_getting_started]: https://github.com/hyperledger-cacti/cacti/blob/main/BUILD.md#getting-started
 [build_doc]: https://github.com/hyperledger-cacti/cacti/blob/main/BUILD.md
 [contributing_doc]: https://github.com/hyperledger-cacti/cacti/blob/main/CONTRIBUTING.md
+[how_to_contribute]: ./contributing/how-to-contribute.md
 [conventions_doc]: https://github.com/hyperledger-cacti/cacti/blob/main/CONVENTIONS.md
 [pull_doc]: https://github.com/hyperledger-cacti/cacti/blob/main/PULL.md
 [ai_guidelines_doc]: https://github.com/hyperledger-cacti/cacti/blob/main/AI_GUIDELINES.md
@@ -27,7 +28,7 @@ set of reference links defined at the bottom of that file.
 [architecture_overview]: ./architecture.md
 [openapi_specs]: https://hyperledger-cacti.github.io/cacti/references/openapi/index.html
 [weaver_doc]: ./weaver/introduction.md
-[satp_hermes]: ./satp-hermes/architecture/satp-hermes.md
+[satp_hermes]: ./satp-hermes/index.md
 [build_configure_cacti]: https://github.com/hyperledger-cacti/cacti/blob/main/BUILD.md#configure-cacti
 [weaver_getting_started]: ./weaver/introduction.md
 [roadmap_doc]: https://github.com/hyperledger-cacti/cacti/blob/main/ROADMAP.md

--- a/docs/docs/use-cases.md
+++ b/docs/docs/use-cases.md
@@ -1,3 +1,7 @@
 # Use Cases and Applications for Cacti
 
-This page is under construction. While we are working on it, you can find compelling examples and sample code [here](https://github.com/hyperledger-cacti/cacti/blob/main/whitepaper/whitepaper.md), [here](./weaver/user-stories/), [here](https://github.com/hyperledger-cacti/cacti/tree/main/examples), and [here](https://github.com/hyperledger-cacti/cacti/tree/main/weaver/samples).
+Explore Cacti use cases and sample implementations through the following resources:
+
+- [Cacti Demos](https://github.com/hyperledger-cacti/cacti-demos) provides runnable examples and demonstration applications.
+- The [Cacti whitepaper](https://github.com/hyperledger-cacti/cacti/blob/main/whitepaper/whitepaper.md) describes the project's architecture and representative use cases.
+- [Weaver samples](https://github.com/hyperledger-cacti/cacti/tree/main/weaver/samples) provide sample applications and network configurations.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,12 +87,12 @@ extra:
 nav:
   - Overview:
     - Introduction: index.md
-    - Start Here: start-here.md
     - Vision: vision.md
     - Architecture: architecture.md
     - Key Concepts:
       - Overview: concepts/index.md
       - Data Sharing: concepts/data-sharing.md
+    - Start Here: start-here.md
     - Use Cases: use-cases.md
   - Platforms:
     - Cactus:
@@ -182,12 +182,12 @@ nav:
       - Specifications: weaver/specifications.md
       - Roadmap: weaver/roadmap.md
       - Publications: weaver/publications.md
-    - SATP Hermes:
-      - Architecture: satp-hermes/architecture/satp-hermes.md
-      - Gateway Configuration: satp-hermes/configuration.md
-      - API Type 3 Adapter Specification: satp-hermes/api3-adapter-spec.md
-      - Database and Migrations: satp-hermes/database.md
-      - Operations: satp-hermes/operations.md
+  - SATP Hermes:
+    - Overview: satp-hermes/index.md
+    - Gateway Configuration: satp-hermes/configuration.md
+    - API Type 3 Adapter Specification: satp-hermes/api3-adapter-spec.md
+    - Database and Migrations: satp-hermes/database.md
+    - Operations: satp-hermes/operations.md
   - Build and Operate:
     - Guides:
       - Getting Started: guides/getting-started.md
@@ -205,6 +205,7 @@ nav:
       - Managing Dependencies: recipes/managing-dependencies.md
       - VS Code Setup: recipes/vscode-setup.md
   - Reference:
+    - Overview: references/index.md
     - Technical Specifications: references/specs.md
     - Publications: references/publications.md
     - Events and Podcasts: references/events.md


### PR DESCRIPTION
<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

Promote SATP Hermes to a top-level documentation section and add a
dedicated landing page backed by the existing MkDocs snippet.

Reorder the Overview navigation and update the use-cases page to link
to Cacti Demos. Add a References landing page for presentations,
research, and demonstration applications.

Direct Start Here readers to the authoritative contribution guide
instead of duplicating its workflow.

Remove stale xDai references from active test and documentation
configuration while preserving historical project records.

## Related issue

Addresses #4596.

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.