### PR TITLE
ci(satp-hermes): pin Foundry to 1.5.1 to stop codegen artifact drift

### DIFF
--- a/.github/workflows/code-quality-checks.yaml
+++ b/.github/workflows/code-quality-checks.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
         with:
-          version: stable
+          version: "1.5.1"
 
       - name: build
         with:

--- a/.github/workflows/satp-hermes-build.yaml
+++ b/.github/workflows/satp-hermes-build.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
         with:
-          version: stable
+          version: "1.5.1"
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/satp-hermes-codegen.yaml
+++ b/.github/workflows/satp-hermes-codegen.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
         with:
-          version: stable
+          version: "1.5.1"
 
       - name: Generate protobuf files
         run: yarn workspace @hyperledger-cacti/cactus-plugin-satp-hermes codegen:proto

--- a/.github/workflows/satp-hermes-publish-docker.yaml
+++ b/.github/workflows/satp-hermes-publish-docker.yaml
@@ -220,7 +220,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
         with:
-          version: stable
+          version: "1.5.1"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/satp-hermes-publish-npmjs-gateway-sdk.yaml
+++ b/.github/workflows/satp-hermes-publish-npmjs-gateway-sdk.yaml
@@ -201,7 +201,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
         with:
-          version: stable
+          version: "1.5.1"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/satp-hermes-workflow.yaml
+++ b/.github/workflows/satp-hermes-workflow.yaml
@@ -385,7 +385,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
         with:
-          version: stable
+          version: "1.5.1"
 
       - name: Build Foundry contracts
         run: |


### PR DESCRIPTION
The yarn_codegen check regenerates forge build artifacts and fails on a dirty tree. Installing Foundry via the rolling `version: stable` channel pulled a newer forge whose artifact JSON differs from the committed files (generated with forge 1.5.1), turning the check red on main. Pin all satp-hermes Foundry installs to 1.5.1 for reproducible output.

Assisted-by: Claude Opus 4.8

<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

<!-- What does this PR do, and why? Keep it concise; reviewers should
     understand the change without reading every commit. -->

## Related issue

<!-- Every PR must reference an issue that has been triaged (labeled
     Triage_Ready). Use a closing keyword so GitHub links the issue:
       Full resolution:  Closes #N | Fixes #N | Resolves #N
       Partial progress: Addresses #N | Refs #N
     PRs that reference an issue still marked Triage_Needed, or that
     reference no issue at all, will be flagged (see PULL.md §9). -->

## PR author checklist

- [x] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [x] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
