### PR TITLE
ci: fix documentation publishing

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -6,13 +6,16 @@ name: Deploy Docs (Github Pages)
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - '*.md'
+      - 'docs/**'
+      - 'packages/**/*.md'
+      - 'weaver/**/*.md'
     tags:
       # only tags with stable versions a.b.c i.e. without -alpha or -dev or -beta etc
       - v[0-9]+.[0-9]+.[0-9]+
-
-    paths:
-      - 'docs/**'
-      - 'packages/cactus-plugin-satp-hermes/docs/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Publishes for each commit to main, all end-user
documentation (root level docs, package docs, and
mkdocs)

<!-- Thanks for contributing to Hyperledger Cacti!
     Please read CONTRIBUTING.md and PULL.md before opening a pull request.
     For rebasing and squashing help see:
     https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing -->

## Description

<!-- What does this PR do, and why? Keep it concise; reviewers should
     understand the change without reading every commit. -->

## Related issue

<!-- Every PR must reference an issue that has been triaged (labeled
     Triage_Ready). Use a closing keyword so GitHub links the issue:
       Full resolution:  Closes #N | Fixes #N | Resolves #N
       Partial progress: Addresses #N | Refs #N
     PRs that reference an issue still marked Triage_Needed, or that
     reference no issue at all, will be flagged (see PULL.md §9). -->

## PR author checklist

- [X] I read and followed the [Pull Request Guidelines](../PULL.md), including linking a `Triage_Ready` issue (§9).
- [X] If AI tools were used, the commit includes an `Assisted-by` tag per [AI Guidelines §2.2](../AI_GUIDELINES.md#22-disclosure). All AI-generated code has been human-reviewed before submission.
